### PR TITLE
Ensure GPIO.cleanup is called

### DIFF
--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -1,6 +1,14 @@
 from __future__ import absolute_import
+
+import atexit
+
 from RPi import GPIO
 
+
+def gpiozero_shutdown():
+    GPIO.cleanup()
+
+atexit.register(gpiozero_shutdown)
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
 


### PR DESCRIPTION
Small patch to ensure GPIO.cleanup is always called on interpreter
shutdown. This just means the library will "play nice" with whatever
comes afterward.