### PR TITLE
Add LED.blink method - ref #7

### DIFF
--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -4,6 +4,11 @@ from RPi import GPIO
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
 
+
+from .devices import (
+    GPIODevice,
+    GPIODeviceError,
+)
 from .input_devices import (
     InputDeviceError,
     InputDevice,
@@ -14,6 +19,7 @@ from .input_devices import (
 )
 from .output_devices import (
     OutputDevice,
+    OutputDeviceError,
     LED,
     Buzzer,
     Motor,

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -1,0 +1,14 @@
+class GPIODeviceError(Exception):
+    pass
+
+
+class GPIODevice(object):
+    def __init__(self, pin=None):
+        if pin is None:
+            raise GPIODeviceError('No GPIO pin number given')
+        self._pin = pin
+
+    @property
+    def pin(self):
+        return self._pin
+

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -7,22 +7,21 @@ from collections import deque
 from RPi import GPIO
 from w1thermsensor import W1ThermSensor
 
+from .devices import GPIODevice, GPIODeviceError
 
-class InputDevice(object):
+
+class InputDeviceError(GPIODeviceError):
+    pass
+
+
+class InputDevice(GPIODevice):
     def __init__(self, pin=None):
-        if pin is None:
-            raise InputDeviceError('No GPIO pin number given')
-
-        self._pin = pin
+        super(InputDevice, self).__init__(pin)
         self._pull = GPIO.PUD_UP
         self._edge = GPIO.FALLING
         self._active_state = 0
         self._inactive_state = 1
         GPIO.setup(pin, GPIO.IN, self._pull)
-
-    @property
-    def pin(self):
-        return self._pin
 
     @property
     def is_active(self):
@@ -79,7 +78,7 @@ class MotionSensor(InputDevice):
 class LightSensor(object):
     def __init__(self, pin=None, darkness_level=0.01):
         if pin is None:
-            raise InputDeviceError('No GPIO pin number given')
+            raise GPIODeviceError('No GPIO pin number given')
 
         self._pin = pin
         self.darkness_level = darkness_level
@@ -123,6 +122,3 @@ class TemperatureSensor(W1ThermSensor):
     def value(self):
         return self.get_temperature()
 
-
-class InputDeviceError(Exception):
-    pass

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1,9 +1,18 @@
 from RPi import GPIO
 
+from time import sleep
+from threading import Thread, Event
 
-class OutputDevice(object):
-    def __init__(self, pin):
-        self.pin = pin
+from .devices import GPIODevice, GPIODeviceError
+
+
+class OutputDeviceError(GPIODeviceError):
+    pass
+
+
+class OutputDevice(GPIODevice):
+    def __init__(self, pin=None):
+        super(OutputDevice, self).__init__(pin)
         GPIO.setup(pin, GPIO.OUT)
 
     def on(self):
@@ -14,7 +23,42 @@ class OutputDevice(object):
 
 
 class LED(OutputDevice):
-    pass
+    def __init__(self, pin=None):
+        super(LED, self).__init__(pin)
+        self._thread = None
+        self._terminate = Event()
+
+    def __del__(self):
+        self._stop_blink()
+
+    def blink(self, on_time, off_time):
+        self._stop_blink()
+        self._terminate.clear()
+        self._thread = Thread(target=self._blink_led, args=(on_time, off_time))
+        self._thread.start()
+
+    def _stop_blink(self):
+        if self._thread:
+            self._terminate.set()
+            self._thread.join()
+            self._thread = None
+
+    def _blink_led(self, on_time, off_time):
+        while True:
+            super(LED, self).on()
+            if self._terminate.wait(on_time):
+                break
+            super(LED, self).off()
+            if self._terminate.wait(off_time):
+                break
+
+    def on(self):
+        self._stop_blink()
+        super(LED, self).on()
+
+    def off(self):
+        self._stop_blink()
+        super(LED, self).off()
 
 
 class Buzzer(OutputDevice):


### PR DESCRIPTION
Adds a background threaded `blink` property to the LED API as suggested in comments to #7. Uses `Event` for termination to ensure quick reaction to requests to stop / change blink cycle (I should change the `MotionSensor` class to use this method too...).

This is a rather messy PR, sorry! I got tired of all the repeated definitions of the read-only `pin` property so this breaks out that into a `GPIODevice` base class which `InputDevice` and `OutputDevice` then inherit from. If you'd rather stick with the repeated definitions let me know and I'll redo this.