### PR TITLE
Shut down GPIO threads nicely

### DIFF
--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -4,14 +4,11 @@ import atexit
 
 from RPi import GPIO
 
-
-def gpiozero_shutdown():
-    GPIO.cleanup()
-
-atexit.register(gpiozero_shutdown)
-GPIO.setmode(GPIO.BCM)
-GPIO.setwarnings(False)
-
+from .devices import (
+    _gpio_threads_shutdown,
+    GPIODeviceError,
+    GPIODevice,
+    )
 from .input_devices import (
     InputDeviceError,
     InputDevice,
@@ -26,3 +23,13 @@ from .output_devices import (
     Buzzer,
     Motor,
 )
+
+
+def gpiozero_shutdown():
+    _gpio_threads_shutdown()
+    GPIO.cleanup()
+
+atexit.register(gpiozero_shutdown)
+GPIO.setmode(GPIO.BCM)
+GPIO.setwarnings(False)
+

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -1,0 +1,43 @@
+from threading import Thread, Event
+
+from RPi import GPIO
+
+
+class GPIODeviceError(Exception):
+    pass
+
+
+class GPIODevice(object):
+    def __init__(self, pin=None):
+        if pin is None:
+            raise GPIODeviceError('No GPIO pin number given')
+        self._pin = pin
+
+    @property
+    def pin(self):
+        return self._pin
+
+
+_GPIO_THREADS = set()
+def _gpio_threads_shutdown():
+    while _GPIO_THREADS:
+        for t in _GPIO_THREADS.copy():
+            t.stop()
+
+
+class GPIOThread(Thread):
+    def __init__(self, group=None, target=None, name=None, args=(), kwargs={}):
+        super(GPIOThread, self).__init__(group, target, name, args, kwargs)
+        self.stopping = Event()
+        self.daemon = True
+
+    def start(self):
+        self.stopping.clear()
+        _GPIO_THREADS.add(self)
+        super(GPIOThread, self).start()
+
+    def stop(self):
+        self.stopping.set()
+        self.join()
+        _GPIO_THREADS.discard(self)
+

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1,9 +1,15 @@
 from RPi import GPIO
 
+from .devices import GPIODeviceError, GPIODevice, GPIOThread
 
-class OutputDevice(object):
-    def __init__(self, pin):
-        self.pin = pin
+
+class OutputDeviceError(GPIODeviceError):
+    pass
+
+
+class OutputDevice(GPIODevice):
+    def __init__(self, pin=None):
+        super(OutputDevice, self).__init__(pin)
         GPIO.setup(pin, GPIO.OUT)
 
     def on(self):
@@ -14,7 +20,36 @@ class OutputDevice(object):
 
 
 class LED(OutputDevice):
-    pass
+    def __init__(self, pin=None):
+        super(LED, self).__init__(pin)
+        self._blink_thread = None
+
+    def blink(self, on_time, off_time):
+        self._stop_blink()
+        self._blink_thread = GPIOThread(target=self._blink_led, args=(on_time, off_time))
+        self._blink_thread.start()
+
+    def _stop_blink(self):
+        if self._blink_thread:
+            self._blink_thread.stop()
+            self._blink_thread = None
+
+    def _blink_led(self, on_time, off_time):
+        while True:
+            super(LED, self).on()
+            if self._blink_thread.stopping.wait(on_time):
+                break
+            super(LED, self).off()
+            if self._blink_thread.stopping.wait(off_time):
+                break
+
+    def on(self):
+        self._stop_blink()
+        super(LED, self).on()
+
+    def off(self):
+        self._stop_blink()
+        super(LED, self).off()
 
 
 class Buzzer(OutputDevice):


### PR DESCRIPTION
The motion sensor queue doesn't shut down properly at script end at the
moment and prevents the interpreter shutting down. This is because it's
a non-daemon thread so `__del__` never gets run and so on.

This is a bit of a major PR - I can split it up if you want. Firstly it
makes a common base class called `GPIODevice` for both `InputDevice` and
`OutputDevice`. This just takes care of the read-only pin stuff. Next it
makes a `GPIOThread` class that ensures its a daemon thread, and which
also ensures proper cleanup on shutdown.

Finally, it fixes `MotionSensor` to use the new `GPIOThread` class
(tested this time! Works nicely) and adds the `blink` method to the
`LED` class (which also works nicely this time).