### PR TITLE
When light when dark

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -154,13 +154,17 @@ while True:
 Retrieve light sensor value:
 
 ```python
+from time import sleep
 from gpiozero import LightSensor
 
-light = LightSensor(6)
+sensor = LightSensor(18)
+led = LED(16)
+
+sensor.when_dark = led.on
+sensor.when_light = led.off
 
 while True:
-    if light.light_detected:
-        print("Light detected")
+    sleep(1)
 ```
 
 ### Temperature Sensor


### PR DESCRIPTION
Experiment: Instead of having a universal `wait_for_input`, have specific `wait_for_X` methods which are relevant to each class. This PR implements `wait_for_dark` and `wait_for_light` on `LightSensor` and adds similar replacements for `add_callback`: `when_dark` and `when_light`. The callbacks are deliberately implemented as attributes instead of methods for a couple of reasons:

* `add_callback` is a bit misleading. It implies you can add as many callbacks as you like but you can't - you can only have one
* Given you can only have a single callback an attribute is much simpler to understand: either it's `None` in which case, no callback is set, or it's a function to call. This makes `remove_callback` redundant
* Unless we like the idea of setting multiple callbacks, in which case methods like add and remove would be a better idea?