### PR TITLE
Flexible events

### DIFF
--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -26,9 +26,9 @@ from .output_devices import (
 )
 from .boards import (
     TrafficLights,
-    PiTraffic
+    PiTraffic,
     FishDish,
-    TrafficHat
+    TrafficHat,
     PiLiter,
 )
 


### PR DESCRIPTION
Permit event callbacks to accept no parameters, or a single (mandatory) parameter providing the source input object (alternatively an optional parameter will be used if one is available)