### PR TITLE
Fix #25

### DIFF
--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -31,6 +31,10 @@ class GPIODevice(object):
     def is_active(self):
         return self._read()
 
+    def __repr__(self):
+        return "<gpiozero.%s object on pin=%d, is_active=%s>" % (
+            self.__class__.__name__, self.pin, self.is_active)
+
 
 _GPIO_THREADS = set()
 

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -36,6 +36,10 @@ class InputDevice(GPIODevice):
     def pull_up(self):
         return self._pull_up
 
+    def __repr__(self):
+        return "<gpiozero.%s object on pin=%d, pull_up=%s, is_active=%s>" % (
+            self.__class__.__name__, self.pin, self.pull_up, self.is_active)
+
 
 class WaitableInputDevice(InputDevice):
     def __init__(self, pin=None, pull_up=False):
@@ -142,6 +146,13 @@ class SmoothedInputDevice(WaitableInputDevice):
         super(SmoothedInputDevice, self).__init__(pin, pull_up)
         self._queue = GPIOQueue(self, queue_len, sample_wait, partial)
         self.threshold = float(threshold)
+
+    def __repr__(self):
+        if self.partial or self._queue.full.wait(0):
+            return super(SmoothedInputDevice, self).__repr__()
+        else:
+            return "<gpiozero.%s object on pin=%d, pull_up=%s>" % (
+                self.__class__.__name__, self.pin, self.pull_up)
 
     @property
     def queue_len(self):


### PR DESCRIPTION
Add a nice `__repr__` to the GPIODevice base class and a slightly refined one to InputDevice.

This isn't much but generally I think `__repr__` implementations should be deliberately simple: firstly, they're frequently used for debugging so if they're at all complex you risk making a debugging tool buggy (very annoying!). Secondly, if you pour too much info into them you risk making the debugging output cluttered, so I tend to prefer keeping it to straight-forward simple to retrieve/calculate info without excessive detail (if the user wants more, they can always query it directly).

There is one refinement here: in SmoothedInputDevice, `__repr__` is
tweaked to ensure that when partial is False (the default), and the
queue isn't filled, `__repr__` doesn't block (because it should *never*
block).