### PR TITLE
Explicit cleanup

### DIFF
--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -1,11 +1,6 @@
 from __future__ import absolute_import
 
-import atexit
-
-from RPi import GPIO
-
 from .devices import (
-    _gpio_threads_shutdown,
     GPIODeviceError,
     GPIODevice,
 )
@@ -35,11 +30,3 @@ from .boards import (
     TrafficHat,
 )
 
-
-def gpiozero_shutdown():
-    _gpio_threads_shutdown()
-    GPIO.cleanup()
-
-atexit.register(gpiozero_shutdown)
-GPIO.setmode(GPIO.BCM)
-GPIO.setwarnings(False)


### PR DESCRIPTION
This is a rather complex PR which partially (but not completely) attempts to fix #38. There are several issues here which include:

* Tracking object lifespan in a garbage collected, dynamic language is *hard*. Hard enough that I'd never expect a newbie programmer to understand it (in the case of GPIO stuff it involves figuring out when objects are being kept alive because a callback they implement is referenced by a chunk of external C code).
* Even if you can track the lifespan you can't force the garbage collector to do what you want. You may think the object can be killed off, but unless the garbage collector agrees that every reference is gone, it's not going to do what you want.
* The RPi.GPIO library isn't really designed for interactive REPL use; it makes several tacit assumptions that GPIOs won't be re-used for things during a single session (or at least not without the requisite cleanup functions being called in the proper order).

Anyway, the upshot is that the following is *never* going to work:

```python
>>> from gpiozero import Button
>>> btn = Button(14)
>>> btn = Button(14)
```

Consider the sequence of events:

1. The gpiozero library is imported and we grab the Button class from it
2. We construct a Button instance bound to GPIO pin 14
3. We assigned that instance to the name `btn`
4. We construct another Button instance bound to GPIO pin 14; this will fail because there's already another instance bound to that pin
5. The re-assignment of the `btn` name never happens because the construction of the new Button instance has already failed

You might be tempted to think the following would work:

```python
>>> from gpiozero import Button
>>> btn = Button(14)
>>> del btn
>>> btn = Button(14)
```

But it won't either because of the effects of callbacks referencing their owning objects alluded to earlier. The only solution to permitting such behaviour is to have an explicit method used to release all acquired resources. In deference to the Python idiom of using `close` for such a method, that's what this PR adds. This means you *can* do the following:

```python
>>> from gpiozero import Button
>>> btn = Button(14)
>>> btn.close()
>>> btn = Button(14)
```

It also adds the ability to use GPIODevice instances as context managers to do this implicitly in a one-shot manner:

```python
with Button(14) as btn:
    # do something with btn
```