### PR TITLE
Docs clean up part 1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,32 @@
 # Contributing
 
-This module was designed for use in education; particularly for young children. It is not intended to replace `RPi.GPIO` and it does not claim to be suitable for all purposes. It is intended to provide a simple interface to everyday components.
+This module was designed for use in education; particularly for young children.
+It is not intended to replace `RPi.GPIO` and it does not claim to be suitable
+for all purposes. It is intended to provide a simple interface to everyday
+components.
 
-If a proposed change added an advanced feature but made basic usage more complex, it is unlikely to be added.
+If a proposed change added an advanced feature but made basic usage more
+complex, it is unlikely to be added.
 
 ## Suggestions
 
-Please make suggestions by opening an [issue](https://github.com/RPi-Distro/python-gpiozero/issues) explaining your reasoning clearly.
+Please make suggestions by opening an
+[issue](https://github.com/RPi-Distro/python-gpiozero/issues) explaining your
+reasoning clearly.
 
 ## Bugs
 
-Please submit bug reports by opening an [issue](https://github.com/RPi-Distro/python-gpiozero/issues) explaining the problem clearly using code examples.
+Please submit bug reports by opening an
+[issue](https://github.com/RPi-Distro/python-gpiozero/issues) explaining the
+problem clearly using code examples.
 
 ## Documentation
 
-The documentation source lives in the [docs](https://github.com/RPi-Distro/python-gpiozero/tree/master/docs) folder and is rendered from markdown into HTML using [mkdocs](http://www.mkdocs.org/). Contributions to the documentation are welcome but should be easy to read and understand.
+The documentation source lives in the
+[docs](https://github.com/RPi-Distro/python-gpiozero/tree/master/docs) folder
+and is rendered from markdown into HTML using [mkdocs](http://www.mkdocs.org/).
+Contributions to the documentation are welcome but should be easy to read and
+understand.
 
 ## Python
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,9 @@ Boards & accessories:
 
 ## Getting started
 
-See the [input devices](inputs.md) and [output devices](outputs.md) to get started. Also see the [boards & accessories](boards.md) page for examples of using the included accessories.
+See the [input devices](inputs.md) and [output devices](outputs.md) to get
+started. Also see the [boards & accessories](boards.md) page for examples of
+using the included accessories.
 
-For common programs using multiple components together, see the [recipes](recipes.md) page.
+For common programs using multiple components together, see the
+[recipes](recipes.md) page.

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -1,10 +1,12 @@
 # Input Devices
 
-These input device component interfaces have been provided for simple use of everyday components.
+These input device component interfaces have been provided for simple use of
+everyday components.
 
 Components must be wired up correctly before used in code.
 
-*Note all GPIO pin numbers use BCM numbering. See the [notes](notes.md) page for more information.*
+*Note all GPIO pin numbers use BCM numbering. See the [notes](notes.md) page
+for more information.*
 
 ## Button
 
@@ -22,13 +24,16 @@ Ensure the `Button` class is imported at the top of the file:
 from gpiozero import Button
 ```
 
-Create a `Button` object by passing in the pin number the button is connected to:
+Create a `Button` object by passing in the pin number the button is connected
+to:
 
 ```python
 button = Button(2)
 ```
 
-The default behaviour is to set the *pull* state of the button to *up*. To change this behaviour, set the `pull_up` argument to `False` when creating your `Button` object.
+The default behaviour is to set the *pull* state of the button to *up*. To
+change this behaviour, set the `pull_up` argument to `False` when creating your
+`Button` object.
 
 ```python
 button = Button(pin=2, pull_up=False)
@@ -67,7 +72,8 @@ Ensure the `MotionSensor` class is imported at the top of the file:
 from gpiozero import MotionSensor
 ```
 
-Create a `MotionSensor` object by passing in the pin number the sensor is connected to:
+Create a `MotionSensor` object by passing in the pin number the sensor is
+connected to:
 
 ```python
 pir = MotionSensor(3)
@@ -97,7 +103,8 @@ Ensure the `LightSensor` class is imported at the top of the file:
 from gpiozero import LightSensor
 ```
 
-Create a `LightSensor` object by passing in the pin number the sensor is connected to:
+Create a `LightSensor` object by passing in the pin number the sensor is
+connected to:
 
 ```python
 light = LightSensor(4)
@@ -145,7 +152,8 @@ temp = TemperatureSensor()
 
 MCP3008 ADC (Analogue-to-Digital converter).
 
-The MCP3008 chip provides access to up to 8 analogue inputs, such as potentiometers, and read their values in digital form.
+The MCP3008 chip provides access to up to 8 analogue inputs, such as
+potentiometers, and read their values in digital form.
 
 ### Wiring
 
@@ -166,7 +174,9 @@ with MCP3008() as pot:
     print(pot.read())
 ```
 
-It is possible to specify the `bus`, the `device` and the `channel` you wish to access. The previous example used the default value of `0` for each of these. To specify them, pass them in as arguments:
+It is possible to specify the `bus`, the `device` and the `channel` you wish to
+access. The previous example used the default value of `0` for each of these.
+To specify them, pass them in as arguments:
 
 ```python
 with MCP3008(bus=1, device=1, channel=4) as pot:

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -2,7 +2,8 @@
 
 1. **BCM pin numbering**
 
-    This library uses BCM pin numbering for the GPIO pins, as opposed to BOARD. Unlike the `RPi.GPIO` library, it is not configurable.
+    This library uses Broadcom (BCM) pin numbering for the GPIO pins, as
+    opposed to BOARD. Unlike the `RPi.GPIO` library, this is not configurable.
 
     Any pin marked `GPIO` can be used for generic components.
 
@@ -36,11 +37,11 @@
     - *5V = 5 Volts*
     - *DNC = Do not connect (special use pins)*
 
-1. **Wiring**
+2. **Wiring**
 
     All components must be wired up correctly before using with this library.
 
-1. **Keep your program alive with `signal.pause`**
+3. **Keep your program alive with `signal.pause`**
 
     The following program looks like it should turn an LED on:
 
@@ -52,9 +53,12 @@
     led.on()
     ```
 
-    And it does, if you're using the Python shell, IPython shell or IDLE shell, but if you saved this program as a Python file and ran it, it would flash on for a moment then the program would end and it would turn off.
+    And it does, if you're using the Python shell, IPython shell or IDLE shell,
+    but if you saved this program as a Python file and ran it, it would flash
+    on for a moment then the program would end and it would turn off.
 
-    The following file includes an intentional `pause` to keep the program alive:
+    The following file includes an intentional `pause` to keep the program
+    alive:
 
     ```python
     from gpiozero import LED
@@ -67,9 +71,11 @@
     pause()
     ```
 
-    Now running the program will stay running, leaving the LED on, until it is forced to quit.
+    Now running the program will stay running, leaving the LED on, until it is
+    forced to quit.
 
-    Similarly, when setting up callbacks on button presses or other input devices, the program needs to be running for the events to be detected:
+    Similarly, when setting up callbacks on button presses or other input
+    devices, the program needs to be running for the events to be detected:
 
     ```python
     from gpiozero import Button

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -1,10 +1,12 @@
 # Output Devices
 
-These output device component interfaces have been provided for simple use of everyday components.
+These output device component interfaces have been provided for simple use of
+everyday components.
 
 Components must be wired up correctly before used in code.
 
-*Note all GPIO pin numbers use BCM numbering. See the [notes](notes.md) page for more information.*
+*Note all GPIO pin numbers use BCM numbering. See the [notes](notes.md) page
+for more information.*
 
 ## LED
 

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -42,20 +42,20 @@ class LEDBoard(object):
         """
         Make all the LEDs turn on and off repeatedly.
 
-        on_time: 1
+        on_time: `1`
             Number of seconds to be on
 
-        off_time: 1
+        off_time: `1`
             Number of seconds to be off
 
-        n: None
+        n: `None`
             Number of times to blink; None means forever
 
-        background: True
-            If True, start a background thread to continue blinking and return
-            immediately. If False, only return when the blink is finished
-            (warning: the default value of n will result in this method never
-            returning).
+        background: `True`
+            If `True`, start a background thread to continue blinking and
+            return immediately. If `False`, only return when the blink is
+            finished (warning: the default value of `n` will result in this
+            method never returning).
         """
         for led in self._leds:
             led.blink(on_time, off_time, n, background)
@@ -74,13 +74,13 @@ class TrafficLights(LEDBoard):
     """
     Generic Traffic Lights set.
 
-    red: None
+    red: `None`
         Red LED pin
 
-    amber: None
+    amber: `None`
         Amber LED pin
 
-    green: None
+    green: `None`
         Green LED pin
     """
     def __init__(self, red=None, amber=None, green=None):
@@ -144,20 +144,20 @@ class FishDish(TrafficLights):
         """
         Make all the board's components turn on and off repeatedly.
 
-        on_time: 1
+        on_time: `1`
             Number of seconds to be on
 
-        off_time: 1
+        off_time: `1`
             Number of seconds to be off
 
-        n: None
+        n: `None`
             Number of times to blink; None means forever
 
-        background: True
-            If True, start a background thread to continue blinking and return
-            immediately. If False, only return when the blink is finished
-            (warning: the default value of n will result in this method never
-            returning).
+        background: `True`
+            If `True`, start a background thread to continue blinking and
+            return immediately. If `False`, only return when the blink is
+            finished (warning: the default value of `n` will result in this
+            method never returning).
         """
         for thing in self._all:
             led.blink(on_time, off_time, n, background)
@@ -185,20 +185,20 @@ class FishDish(TrafficLights):
         """
         Make all the board's LEDs turn on and off repeatedly.
 
-        on_time: 1
+        on_time: `1`
             Number of seconds to be on
 
-        off_time: 1
+        off_time: `1`
             Number of seconds to be off
 
-        n: None
+        n: `None`
             Number of times to blink; None means forever
 
-        background: True
-            If True, start a background thread to continue blinking and return
-            immediately. If False, only return when the blink is finished
-            (warning: the default value of n will result in this method never
-            returning).
+        background: `True`
+            If `True`, start a background thread to continue blinking and
+            return immediately. If `False`, only return when the blink is
+            finished (warning: the default value of `n` will result in this
+            method never returning).
         """
         super(FishDish, self).blink(on_time, off_time, n, background)
 
@@ -234,7 +234,7 @@ class Robot(object):
         Make the robot turn left. If seconds given, stop after given number of
         seconds.
 
-        seconds: None
+        seconds: `None`
             Number of seconds to turn left for
         """
         self._left.forward()
@@ -249,7 +249,7 @@ class Robot(object):
         Make the robot turn right. If seconds given, stop after given number of
         seconds.
 
-        seconds: None
+        seconds: `None`
             Number of seconds to turn right for
         """
         self._right.forward()
@@ -261,9 +261,10 @@ class Robot(object):
 
     def forward(self, seconds=None):
         """
-        Drive the robot forward. If seconds given, stop after given number of seconds.
+        Drive the robot forward. If seconds given, stop after given number of
+        seconds.
 
-        seconds: None
+        seconds: `None`
             Number of seconds to drive forward for
         """
         self._left.forward()
@@ -275,9 +276,10 @@ class Robot(object):
 
     def backward(self, seconds=None):
         """
-        Drive the robot backward. If seconds given, stop after given number of seconds.
+        Drive the robot backward. If seconds given, stop after given number of
+        seconds.
 
-        seconds: None
+        seconds: `None`
             Number of seconds to drive backward for
         """
         self._left.backward()

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -14,7 +14,11 @@ class OutputDeviceError(GPIODeviceError):
 
 class OutputDevice(GPIODevice):
     """
-    Generic GPIO Output Device (on/off).
+    Represents a generic GPIO output device.
+
+    This class extends `GPIODevice` to add facilities common to GPIO output
+    devices: an `on` method to switch the device on, and a corresponding `off`
+    method.
     """
     def __init__(self, pin=None):
         super(OutputDevice, self).__init__(pin)
@@ -46,7 +50,12 @@ class OutputDevice(GPIODevice):
 
 class DigitalOutputDevice(OutputDevice):
     """
-    Generic Digital GPIO Output Device (on/off/toggle/blink).
+    Represents a generic output device with typical on/off behaviour.
+
+    This class extends `OutputDevice` with a `toggle` method to switch the
+    device between its on and off states, and a `blink` method which uses an
+    optional background thread to handle toggling the device state without
+    further interaction.
     """
     def __init__(self, pin=None):
         super(DigitalOutputDevice, self).__init__(pin)
@@ -125,6 +134,10 @@ class DigitalOutputDevice(OutputDevice):
 class LED(DigitalOutputDevice):
     """
     An LED (Light Emmitting Diode) component.
+
+    A typical configuration of such a device is to connect a GPIO pin to the
+    anode (long leg) of the LED, and the cathode (short leg) to ground, with
+    an optional resistor to prevent the LED from burning out.
     """
     pass
 
@@ -132,6 +145,9 @@ class LED(DigitalOutputDevice):
 class Buzzer(DigitalOutputDevice):
     """
     A digital Buzzer component.
+
+    A typical configuration of such a device is to connect a GPIO pin to the
+    anode (long leg) of the buzzer, and the cathode (short leg) to ground.
     """
     pass
 


### PR DESCRIPTION
Big push on getting the docs cleaned up before 1.0. Proper wrapping of
everything so it's decently viewable from the command line (or as
decently viewable as markdown can be - the tables will never look great
from the command line).

Only one code change in this PR: rename `bouncetime` to `bounce_time`
(everything else is PEP-8, so this probably should be too) and change
its units to seconds from milliseconds (again, all other durations in
the library are in seconds, so it feels inconsistent that this one
isn't; for the sake of those who won't read the docs - which is most
people - I figure consistency helps with guessing!).

