### PR TITLE
Fix #74

### DIFF
--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -47,7 +47,11 @@ class GPIODevice(object):
         The GPIO pin (in BCM numbering) that the device is connected to. If
         this is `None` a `GPIODeviceError` will be raised.
     """
+
+    __slots__ = ('_pin', '_active_state', '_inactive_state')
+
     def __init__(self, pin=None):
+        super(GPIODevice, self).__init__()
         # self._pin must be set before any possible exceptions can be raised
         # because it's accessed in __del__. However, it mustn't be given the
         # value of pin until we've verified that it isn't already allocated


### PR DESCRIPTION
Add more property aliases and do them properly (no more lambdas and
string lookups) which means we can remove `_alias`. This commit also
defines `__slots__` for all classes which should prevent assignation of
invalid attributes with an AttributeError (more friendly than silently
doing the wrong thing). Finally, it cleans up all the property defs to
use Ben's preferred decorator style.