### PR TITLE
Fix #107

### DIFF
--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -32,6 +32,10 @@ class LEDBoard(SourceMixin, CompositeDevice):
             led.close()
 
     @property
+    def closed(self):
+        return all(led.closed for led in self.leds)
+
+    @property
     def leds(self):
         """
         A tuple of all the `LED` objects contained by the instance.
@@ -189,6 +193,10 @@ class TrafficLightsBuzzer(SourceMixin, CompositeDevice):
         self.button.close()
 
     @property
+    def closed(self):
+        return all(o.closed for o in self.all)
+
+    @property
     def all(self):
         """
         A tuple containing objects for all the items on the board (several
@@ -304,6 +312,24 @@ class Robot(SourceMixin, CompositeDevice):
     def close(self):
         self._left.close()
         self._right.close()
+
+    @property
+    def closed(self):
+        return self._left.closed and self._right.closed
+
+    @property
+    def left_motor(self):
+        """
+        Returns the `Motor` device representing the robot's left motor.
+        """
+        return self._left
+
+    @property
+    def right_motor(self):
+        """
+        Returns the `Motor` device representing the robot's right motor.
+        """
+        return self._right
 
     @property
     def value(self):

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -82,7 +82,19 @@ class GPIOBase(object):
         # safely called from subclasses without worrying whether super-class'
         # have it (which in turn is useful in conjunction with the SourceMixin
         # class).
+        """
+        Shut down the device and release all associated resources.
+        """
         pass
+
+    @property
+    def closed(self):
+        """
+        Returns `True` if the device is closed (see the `close` method). Once a
+        device is closed you can no longer use any other methods or properties
+        to control or query the device.
+        """
+        return False
 
     def __enter__(self):
         return self
@@ -150,7 +162,8 @@ class CompositeDevice(ValuesMixin, GPIOBase):
     Represents a device composed of multiple GPIO devices like simple HATs,
     H-bridge motor controllers, robots composed of multiple motors, etc.
     """
-    pass
+    def __repr__(self):
+        return "<gpiozero.%s object>" % (self.__class__.__name__)
 
 
 class GPIODevice(ValuesMixin, GPIOBase):
@@ -199,15 +212,6 @@ class GPIODevice(ValuesMixin, GPIOBase):
             raise GPIODeviceClosed(
                 '%s is closed or uninitialized' % self.__class__.__name__)
 
-    @property
-    def closed(self):
-        """
-        Returns `True` if the device is closed (see the `close` method). Once a
-        device is closed you can no longer use any other methods or properties
-        to control or query the device.
-        """
-        return self._pin is None
-
     def close(self):
         """
         Shut down the device and release all associated resources.
@@ -253,6 +257,10 @@ class GPIODevice(ValuesMixin, GPIOBase):
                 _GPIO_PINS.remove(pin)
                 GPIO.remove_event_detect(pin)
                 GPIO.cleanup(pin)
+
+    @property
+    def closed(self):
+        return self._pin is None
 
     @property
     def pin(self):


### PR DESCRIPTION
Add `forward_device` and `backward_device` to `Motor`, `left_motor` and
`right_motor` to `Robot`, and ensure all `CompositeDevice` descendents have a
proper `close()` method and `closed` property. Also, add a few more
`_check_open` calls around the place to make sure `GPIODeviceClosed` is
properly raised in response to read and writing values.