### PR TITLE
Fix master packaging to work on jessie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,12 @@ SUBDIRS:=
 DIST_EGG=dist/$(NAME)-$(VER)-$(PYVER).egg
 DIST_TAR=dist/$(NAME)-$(VER).tar.gz
 DIST_ZIP=dist/$(NAME)-$(VER).zip
-DIST_DEB=dist/python-$(NAME)_$(VER)-1$(DEB_SUFFIX)_all.deb \
-	dist/python3-$(NAME)_$(VER)-1$(DEB_SUFFIX)_all.deb \
-	dist/$(NAME)_$(VER)-1$(DEB_SUFFIX)_$(DEB_ARCH).changes
-DIST_DSC=dist/$(NAME)_$(VER)-1$(DEB_SUFFIX).tar.gz \
-	dist/$(NAME)_$(VER)-1$(DEB_SUFFIX).dsc \
-	dist/$(NAME)_$(VER)-1$(DEB_SUFFIX)_source.changes
+DIST_DEB=dist/python-$(NAME)_$(VER)$(DEB_SUFFIX)_all.deb \
+	dist/python3-$(NAME)_$(VER)$(DEB_SUFFIX)_all.deb \
+	dist/$(NAME)_$(VER)$(DEB_SUFFIX)_$(DEB_ARCH).changes
+DIST_DSC=dist/$(NAME)_$(VER)$(DEB_SUFFIX).tar.gz \
+	dist/$(NAME)_$(VER)$(DEB_SUFFIX).dsc \
+	dist/$(NAME)_$(VER)$(DEB_SUFFIX)_source.changes
 MAN_PAGES=
 
 
@@ -106,7 +106,6 @@ test:
 clean:
 	$(PYTHON) $(PYFLAGS) setup.py clean
 	$(MAKE) -f $(CURDIR)/debian/rules clean
-	$(MAKE) -C docs clean
 	rm -fr build/ dist/ $(NAME).egg-info/ tags
 	for dir in $(SUBDIRS); do \
 		$(MAKE) -C $$dir clean; \
@@ -156,7 +155,7 @@ release: $(PY_SOURCES) $(DOC_SOURCES) $(DEB_SOURCES)
 	# ensure there are no current uncommitted changes
 	test -z "$(shell git status --porcelain)"
 	# update the debian changelog with new release information
-	dch --newversion $(VER)-1$(DEB_SUFFIX) --controlmaint
+	dch --newversion $(VER)$(DEB_SUFFIX) --controlmaint
 	# commit the changes and add a new tag
 	git commit debian/changelog -m "Updated changelog for release $(VER)"
 	git tag -s release-$(VER) -m "Release $(VER)"
@@ -167,8 +166,8 @@ upload: $(PY_SOURCES) $(DOC_SOURCES) $(DIST_DEB) $(DIST_DSC)
 	# build a source archive and upload to PyPI
 	$(PYTHON) $(PYFLAGS) setup.py sdist upload
 	# build the deb source archive and upload to Raspbian
-	dput raspberrypi dist/$(NAME)_$(VER)-1$(DEB_SUFFIX)_source.changes
-	dput raspberrypi dist/$(NAME)_$(VER)-1$(DEB_SUFFIX)_$(DEB_ARCH).changes
+	dput raspberrypi dist/$(NAME)_$(VER)$(DEB_SUFFIX)_source.changes
+	dput raspberrypi dist/$(NAME)_$(VER)$(DEB_SUFFIX)_$(DEB_ARCH).changes
 	git push --tags
 
 .PHONY: all install develop test doc source egg zip tar deb dist clean tags release upload $(SUBDIRS)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-gpiozero (0.9.0-1) stable; urgency=medium
+gpiozero (0.9.0) stable; urgency=medium
 
   * Added source and values properties to all relevant classes (#76)
   * Fix names of parameters in Motor constructor (#79)
@@ -6,7 +6,7 @@ gpiozero (0.9.0-1) stable; urgency=medium
 
  -- Dave Jones <dave@waveform.org.uk>  Sun, 25 Oct 2015 18:56:58 +0100
 
-gpiozero (0.8.0-1) stable; urgency=medium
+gpiozero (0.8.0) stable; urgency=medium
 
   * Added generic AnalogInputDevice class along with specific classes for the
     MCP3008 and MCP3004 (#41)
@@ -14,13 +14,13 @@ gpiozero (0.8.0-1) stable; urgency=medium
 
  -- Dave Jones <dave@waveform.org.uk>  Fri, 16 Oct 2015 11:40:42 +0100
 
-gpiozero (0.7.0-1) stable; urgency=medium
+gpiozero (0.7.0) stable; urgency=medium
 
   * Second public beta
 
  -- Dave Jones <dave@waveform.org.uk>  Fri, 09 Oct 2015 12:30:13 +0100
 
-gpiozero (0.6.0-1) stable; urgency=medium
+gpiozero (0.6.0) stable; urgency=medium
 
   * Raspbian packaging (#44)
   * PWM functionality including variable level RGB LEDs (#40)

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Homepage: http://github.com/RPi-Distro/python-gpiozero
 Section: python
 Priority: extra
 Build-Depends: debhelper (>= 8), python-all (>= 2.7), python-setuptools, python3-all, python3-setuptools
-Standards-Version: 3.9.3
+Standards-Version: 3.9.6
 X-Python-Version: >= 2.7
 X-Python3-Version: >= 3.2
 


### PR DESCRIPTION
Looks like lintian on Jessie includes some new tests. In particular,
native packages can't have a release version.