### PR TITLE
Add missing InputDeviceError import to devices.py

### DIFF
--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -12,6 +12,7 @@ from collections import deque
 
 from RPi import GPIO
 
+from .input_devices import InputDeviceError
 
 _GPIO_THREADS = set()
 _GPIO_PINS = set()


### PR DESCRIPTION
Line 316 raises an InputDeviceError, but the import for that error seems to be missing.