### PR TITLE
Move exceptions to their own sub-module

### DIFF
--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -5,13 +5,16 @@ from __future__ import (
     division,
 )
 
-from .devices import (
+from .exc import (
     GPIODeviceClosed,
     GPIODeviceError,
+    InputDeviceError,
+    OutputDeviceError,
+)
+from .devices import (
     GPIODevice,
 )
 from .input_devices import (
-    InputDeviceError,
     InputDevice,
     Button,
     LineSensor,
@@ -22,7 +25,6 @@ from .input_devices import (
     MCP3004,
 )
 from .output_devices import (
-    OutputDeviceError,
     OutputDevice,
     PWMOutputDevice,
     PWMLED,

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -12,8 +12,9 @@ except ImportError:
 from time import sleep
 from collections import namedtuple
 
-from .input_devices import InputDeviceError, Button
-from .output_devices import OutputDeviceError, LED, PWMLED, Buzzer, Motor
+from .exc import InputDeviceError, OutputDeviceError
+from .input_devices import Button
+from .output_devices import LED, PWMLED, Buzzer, Motor
 from .devices import CompositeDevice, SourceMixin
 
 

--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -1,0 +1,19 @@
+from __future__ import (
+    unicode_literals,
+    print_function,
+    absolute_import,
+    division,
+)
+
+class GPIODeviceError(Exception):
+    pass
+
+class GPIODeviceClosed(GPIODeviceError):
+    pass
+
+class InputDeviceError(GPIODeviceError):
+    pass
+
+class OutputDeviceError(GPIODeviceError):
+    pass
+

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -14,17 +14,8 @@ from threading import Event
 from RPi import GPIO
 from spidev import SpiDev
 
-from .devices import (
-    GPIODeviceError,
-    GPIODeviceClosed,
-    GPIODevice,
-    CompositeDevice,
-    GPIOQueue,
-)
-
-
-class InputDeviceError(GPIODeviceError):
-    pass
+from .exc import InputDeviceError, GPIODeviceError, GPIODeviceClosed
+from .devices import GPIODevice, CompositeDevice, GPIOQueue
 
 
 class InputDevice(GPIODevice):

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -12,18 +12,8 @@ from itertools import repeat
 
 from RPi import GPIO
 
-from .devices import (
-    GPIODeviceError,
-    GPIODeviceClosed,
-    GPIODevice,
-    GPIOThread,
-    CompositeDevice,
-    SourceMixin,
-)
-
-
-class OutputDeviceError(GPIODeviceError):
-    pass
+from .exc import OutputDeviceError, GPIODeviceError, GPIODeviceClosed
+from .devices import GPIODevice, GPIOThread, CompositeDevice, SourceMixin
 
 
 class OutputDevice(SourceMixin, GPIODevice):


### PR DESCRIPTION
This removes the circular dependency introduced in PR #137. This also
fixes up an issue in the base meta-class which meant it wasn't working
in Python 3 (only Python 2), and adds a bit to the meta-class to allow
docstrings to be inherited (taken from the rest-docs branch).