### PR TITLE
Documentation fix

### DIFF
--- a/docs/api_pins.rst
+++ b/docs/api_pins.rst
@@ -105,6 +105,8 @@ NativePin
 Abstract Pin
 ============
 
+.. currentmodule:: gpiozero.pins
+
 .. autoclass:: Pin
     :members:
 


### PR DESCRIPTION
To stop http://gpiozero.readthedocs.org/en/latest/api_pins.html#abstract-pin saying "class gpiozero.pins.native.Pin"
(which AFAICT is wrong)