### PR TITLE
MockPin fixups

### DIFF
--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -64,9 +64,10 @@ class MockPin(Pin):
 
     def _set_state(self, value):
         if self._function == 'input':
-            raise PinSetInput()
+            raise PinSetInput('cannot set state of pin %r' % self)
         assert self._function == 'output'
         assert 0 <= value <= 1
+        value = bool(value)
         if self._state != value:
             t = time()
             self._state = value
@@ -77,7 +78,8 @@ class MockPin(Pin):
         return None
 
     def _set_frequency(self, value):
-        raise PinPWMUnsupported()
+        if value is not None:
+            raise PinPWMUnsupported()
 
     def _get_pull(self):
         return self._pull
@@ -158,6 +160,18 @@ class MockPWMPin(MockPin):
     def __init__(self, number):
         super(MockPWMPin, self).__init__(number)
         self._frequency = None
+
+    def _set_state(self, value):
+        if self._function == 'input':
+            raise PinSetInput('cannot set state of pin %r' % self)
+        assert self._function == 'output'
+        assert 0 <= value <= 1
+        value = float(value)
+        if self._state != value:
+            t = time()
+            self._state = value
+            self.states.append(PinState(t - self._last_change, value))
+            self._last_change = t
 
     def _get_frequency(self):
         return self._frequency

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -24,8 +24,9 @@ def test_mock_pin_init():
     assert MockPin(2).number == 2
 
 def test_mock_pin_frequency_unsupported():
+    pin = MockPin(3)
+    pin.frequency = None
     with pytest.raises(PinPWMUnsupported):
-        pin = MockPin(3)
         pin.frequency = 100
 
 def test_mock_pin_frequency_supported():


### PR DESCRIPTION
* alter the PinSetInput exception message to match other `Pin` implementations
* constrain the state of MockPin to a `bool`, and the state of MockPWMPin to a `float`
* allow MockPin to have a `None` frequency set, matching the docs http://gpiozero.readthedocs.org/en/latest/api_pins.html#gpiozero.pins.Pin.frequency