### PR TITLE
fix various bugs found by the 'prospector' static-analysis tool

### DIFF
--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -50,7 +50,6 @@ from .input_devices import (
     MotionSensor,
     LightSensor,
     DistanceSensor,
-    AnalogInputDevice,
     MCP3001,
     MCP3002,
     MCP3004,

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -9,7 +9,6 @@ try:
 except ImportError:
     pass
 
-from time import sleep
 from collections import namedtuple
 from itertools import repeat, cycle, chain
 

--- a/gpiozero/compat.py
+++ b/gpiozero/compat.py
@@ -49,5 +49,5 @@ def median(data):
         return data[n // 2]
     else:
         i = n // 2
-        return (data[n - 1] + data[n]) / 2
+        return (data[i - 1] + data[i]) / 2
 

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -333,7 +333,9 @@ class GPIODevice(ValuesMixin, GPIOBase):
 
 
 class GPIOThread(Thread):
-    def __init__(self, group=None, target=None, name=None, args=(), kwargs={}):
+    def __init__(self, group=None, target=None, name=None, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
         super(GPIOThread, self).__init__(group, target, name, args, kwargs)
         self.stopping = Event()
         self.daemon = True

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -8,7 +8,6 @@ from __future__ import (
 )
 
 import inspect
-import warnings
 from functools import wraps
 from time import sleep, time
 from threading import Event
@@ -639,7 +638,7 @@ class DistanceSensor(SmoothedInputDevice):
     def __init__(
             self, echo=None, trigger=None, queue_len=30, max_distance=1,
             threshold_distance=0.3, partial=False):
-        if not (max_distance > 0):
+        if max_distance <= 0:
             raise ValueError('invalid maximum distance (must be positive)')
         self._trigger = None
         super(DistanceSensor, self).__init__(
@@ -955,7 +954,7 @@ class MCP33xx(MCP3xxx):
         data = data[-2:]
         result = ((data[0] & 63) << 7) | (data[1] >> 1)
         # Account for the sign bit
-        if self.differential and value > 4095:
+        if self.differential and result > 4095:
             result = -(8192 - result)
         assert -4096 <= result < 4096
         return result

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -5,8 +5,6 @@ from __future__ import (
     division,
 )
 
-import warnings
-from time import sleep
 from threading import Lock
 from itertools import repeat, cycle, chain
 

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -37,7 +37,7 @@ class MockPin(Pin):
         try:
             old_pin = cls._PINS[number]
         except KeyError:
-            self = super(Pin, cls).__new__(cls)
+            self = super(MockPin, cls).__new__(cls)
             cls._PINS[number] = self
             self._number = number
             self._function = 'input'

--- a/gpiozero/pins/pigpiod.py
+++ b/gpiozero/pins/pigpiod.py
@@ -14,6 +14,7 @@ from ..exc import (
     PinSetInput,
     PinFixedPull,
     PinInvalidPull,
+    PinInvalidState,
     )
 
 
@@ -126,7 +127,7 @@ class PiGPIOPin(Pin):
         if self._host == 'localhost':
             return "GPIO%d" % self._number
         else:
-            return "GPIO%d on %s:%d" % (self._host, self._port)
+            return "GPIO%d on %s:%d" % (self._number, self._host, self._port)
 
     @property
     def host(self):
@@ -173,7 +174,7 @@ class PiGPIOPin(Pin):
             try:
                 self._connection.set_PWM_dutycycle(self._number, int(value * 255))
             except pigpio.error:
-                raise PinInvalidValue('invalid state "%s" for pin %r' % (value, self))
+                raise PinInvalidState('invalid state "%s" for pin %r' % (value, self))
         elif self.function == 'input':
             raise PinSetInput('cannot set state of pin %r' % self)
         else:

--- a/gpiozero/pins/rpio.py
+++ b/gpiozero/pins/rpio.py
@@ -19,6 +19,8 @@ from ..exc import (
     PinSetInput,
     PinFixedPull,
     PinInvalidPull,
+    PinInvalidState,
+    PinPWMError,
     )
 
 
@@ -120,7 +122,7 @@ class RPIOPin(Pin):
 
     def _set_state(self, value):
         if not 0 <= value <= 1:
-            raise PinInvalidValue('invalid state "%s" for pin %r' % (value, self))
+            raise PinInvalidState('invalid state "%s" for pin %r' % (value, self))
         if self._pwm:
             RPIO.PWM.clear_channel_gpio(0, self._number)
             if value == 0:


### PR DESCRIPTION
After finding *another* case of a missing Exception-import, I figured "there has to be a better way" so did a bit of searching and found https://github.com/landscapeio/prospector

There were a whole load of `Import XXXXX should be placed at the top of the module` and `Redefining built-in 'str'` and `Access to a protected member YYYYY of a client class` warnings which I ignored, and these are the specific problems I'm fixing in this commit:
 * gpiozero/\_\_init\_\_.py line 42: `pylint: reimported / Reimport 'AnalogInputDevice' (imported line 42)` (`AnalogInputDevice` was in the list twice)
 * gpiozero/boards.py line 12: `pylint: unused-import / Unused sleep imported from time`
 * gpiozero/compat.py line 51: `pylint: unused-variable / Unused variable 'i' (col 8)` (I used https://hg.python.org/cpython/file/3.4/Lib/statistics.py#l337 as the correct code)
 * gpiozero/devices.py line 336: `dangerous-default-value / Dangerous default value {} as argument (col 4)` (I used https://hg.python.org/cpython/file/3.4/Lib/threading.py#l733 to match up the prototype)
 * gpiozero/input_devices.py line 11: `pylint: unused-import / Unused import warnings` and line 642: `pylint: unneeded-not / Consider changing "not max_distance > 0" to "max_distance <= 0" (col 11)` and line 958: `pylint: undefined-variable / Undefined variable 'value' (col 33)`
 * gpiozero/output_devices.py line 8: `pylint: unused-import / Unused import warnings` and line 9: `pylint: unused-import / Unused sleep imported from time`
 * gpiozero/pins/mock.py line 40: `pylint: bad-super-call / Bad first argument 'Pin' given to super() (col 19)`
 * gpiozero/pins/pigpiod.py line 129: `pylint: too-few-format-args / Not enough arguments for format string (col 19)` and line 176: `pylint: undefined-variable / Undefined variable 'PinInvalidValue' (col 22)`
 * gpiozero/pins/rpio.py line 123: `pylint: undefined-variable / Undefined variable 'PinInvalidValue' (col 18)` and line 137: `pylint: undefined-variable / Undefined variable 'PinInvalidState' (col 22)` and line 163: `pylint: undefined-variable / Undefined variable 'PinPWMError' (col 18)`

All the unit-tests still pass with both Py2.7 and Py3.2 - but let me know if there's anything I've "fixed" that I shouldn't have, or anything I should have fixed in a different way, and I'll happily update this PR.