### PR TITLE
Correction on Traffic Lights Alternative recipe

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -167,6 +167,8 @@ Alternatively::
     from time import sleep
     from signal import pause
 
+    lights = TrafficLights(2, 3, 4)
+
     def traffic_light_sequence():
         while True:
             yield (0, 0, 1) # green


### PR DESCRIPTION
I got an error when using the documented example.
`NameError: name 'lights' is not defined`

This PR fixes that error