### PR TITLE
Fix #181

### DIFF
--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -31,6 +31,9 @@ class GPIOBadQueueLen(GPIODeviceError, ValueError):
 class GPIOBadSampleWait(GPIODeviceError, ValueError):
     "Error raised when a negative sampling wait period is specified"
 
+class GPIOBadSourceDelay(GPIODeviceError, ValueError):
+    "Error raised when a negative source delay is specified"
+
 class InputDeviceError(GPIODeviceError):
     "Base class for errors specific to the InputDevice hierarchy"
 


### PR DESCRIPTION
Added source_delay property to SourceMixin which means it'll now appear
everywhere. Default is 0.01 which is just enough to drop CPU usage while
remaining responsive enough for the majority of purposes.