### PR TITLE
Fix #229

### DIFF
--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -58,6 +58,9 @@ class PinInvalidPull(PinError, ValueError):
 class PinInvalidEdges(PinError, ValueError):
     "Error raised when attempting to assign an invalid edge detection to a pin"
 
+class PinInvalidBounce(PinError, ValueError):
+    "Error raised when attempting to assign an invalid bounce time to a pin"
+
 class PinSetInput(PinError, AttributeError):
     "Error raised when attempting to set a read-only pin"
 

--- a/gpiozero/pins/pigpiod.py
+++ b/gpiozero/pins/pigpiod.py
@@ -14,6 +14,7 @@ from ..exc import (
     PinSetInput,
     PinFixedPull,
     PinInvalidPull,
+    PinInvalidBounce,
     )
 
 
@@ -216,6 +217,8 @@ class PiGPIOPin(Pin):
     def _set_bounce(self, value):
         if value is None:
             value = 0
+        elif value < 0:
+            raise PinInvalidBounce('bounce must be 0 or greater')
         self._connection.set_glitch_filter(self._number, int(value * 1000000))
 
     def _get_edges(self):

--- a/gpiozero/pins/rpigpio.py
+++ b/gpiozero/pins/rpigpio.py
@@ -15,6 +15,7 @@ from ..exc import (
     PinFixedPull,
     PinInvalidPull,
     PinInvalidState,
+    PinInvalidBounce,
     PinPWMFixedValue,
     )
 
@@ -186,10 +187,12 @@ class RPiGPIOPin(Pin):
         return None if self._bounce == -666 else (self._bounce / 1000)
 
     def _set_bounce(self, value):
+        if value is not None and value < 0:
+            raise PinInvalidBounce('bounce must be 0 or greater')
         f = self.when_changed
         self.when_changed = None
         try:
-            self._bounce = -666 if value is None else (value * 1000)
+            self._bounce = -666 if value is None else int(value * 1000)
         finally:
             self.when_changed = f
 

--- a/gpiozero/pins/rpio.py
+++ b/gpiozero/pins/rpio.py
@@ -19,6 +19,7 @@ from ..exc import (
     PinSetInput,
     PinFixedPull,
     PinInvalidPull,
+    PinInvalidBounce,
     )
 
 
@@ -177,10 +178,12 @@ class RPIOPin(Pin):
         return None if self._bounce is None else (self._bounce / 1000)
 
     def _set_bounce(self, value):
+        if value is not None and value < 0:
+            raise PinInvalidBounce('bounce must be 0 or greater')
         f = self.when_changed
         self.when_changed = None
         try:
-            self._bounce = None if value is None else (value * 1000)
+            self._bounce = None if value is None else int(value * 1000)
         finally:
             self.when_changed = f
 


### PR DESCRIPTION
Make sure bounce is always integer when passed to RPi.GPIO and RPIO, and
added some checks to make sure a negative bounce isn't specified either