### PR TITLE
Fix #193

### DIFF
--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -27,7 +27,6 @@ from .exc import (
     OutputDeviceError,
     OutputDeviceBadValue,
     PinError,
-    PinFixedFunction,
     PinInvalidFunction,
     PinInvalidState,
     PinInvalidPull,

--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -64,9 +64,6 @@ class OutputDeviceBadValue(OutputDeviceError, ValueError):
 class PinError(GPIOZeroError):
     "Base class for errors related to pin implementations"
 
-class PinFixedFunction(PinError, AttributeError):
-    "Error raised when attempting to change the function of a fixed type pin"
-
 class PinInvalidFunction(PinError, ValueError):
     "Error raised when attempting to change the function of a pin to an invalid value"
 

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -39,8 +39,7 @@ class InputDevice(GPIODevice):
     def __init__(self, pin=None, pull_up=False):
         super(InputDevice, self).__init__(pin)
         try:
-            if self.pin.function != 'input':
-                self.pin.function = 'input'
+            self.pin.function = 'input'
             pull = 'up' if pull_up else 'down'
             if self.pin.pull != pull:
                 self.pin.pull = pull

--- a/gpiozero/pins/__init__.py
+++ b/gpiozero/pins/__init__.py
@@ -7,7 +7,7 @@ from __future__ import (
 str = type('')
 
 from ..exc import (
-    PinFixedFunction,
+    PinInvalidFunction,
     PinSetInput,
     PinFixedPull,
     PinPWMUnsupported,
@@ -30,12 +30,12 @@ class Pin(object):
     overridden:
 
     * :meth:`_get_function`
+    * :meth:`_set_function`
     * :meth:`_get_state`
 
     The following functions *may* be overridden if applicable:
 
     * :meth:`close`
-    * :meth:`_set_function`
     * :meth:`_set_state`
     * :meth:`_get_frequency`
     * :meth:`_set_frequency`
@@ -105,7 +105,9 @@ class Pin(object):
         return "input"
 
     def _set_function(self, value):
-        raise PinFixedFunction("Cannot set the function of pin %r" % self)
+        if value != "input":
+            raise PinInvalidFunction(
+                "Cannot set the function of pin %r to %s" % (self, value))
 
     function = property(
         lambda self: self._get_function(),
@@ -119,8 +121,7 @@ class Pin(object):
         With certain pin types (e.g. GPIO pins), this attribute can be changed
         to configure the function of a pin. If an invalid function is
         specified, for this attribute, :exc:`PinInvalidFunction` will be
-        raised. If this pin is fixed function and an attempt is made to set
-        this attribute, :exc:`PinFixedFunction` will be raised.
+        raised.
         """)
 
     def _get_state(self):


### PR DESCRIPTION
Changed pin.function so that it's always read-write, which in turn
permits InputDevice to force pin.function to "input" rather than
checking that it's not "input" first. This ensures internal state in
RPi.GPIO and RPIO reflects the reality of each pin's function (see
discussion under the ticket for more detail).