### PR TITLE
Add LEDBarGraph to the composed_devices graph

### DIFF
--- a/docs/images/composed_devices.dot
+++ b/docs/images/composed_devices.dot
@@ -8,6 +8,8 @@ digraph classes {
     RGBLED->PWMLED;
     LEDBoard->LED;
     LEDBoard->PWMLED;
+    LEDBarGraph->LED;
+    LEDBarGraph->PWMLED;
 
     TrafficLightsBuzzer->TrafficLights;
     TrafficLightsBuzzer->Buzzer;


### PR DESCRIPTION
Feel free to reject if this ends up making the [graph](http://gpiozero.readthedocs.org/en/latest/api_generic.html) too cluttered. Alternatively I guess the "LEDBoard" node could be changed to "LEDBoard / LEDBarGraph" ?