### PR TITLE
Remove the CompositeDevice.tuple() method

### DIFF
--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -329,12 +329,8 @@ class CompositeDevice(Device):
         return all(device.closed for device in self)
 
     @property
-    def tuple(self):
-        return self._tuple
-
-    @property
     def value(self):
-        return self.tuple(*(device.value for device in self))
+        return self._tuple(*(device.value for device in self))
 
     @property
     def is_active(self):

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -90,7 +90,7 @@ def test_composite_device_sequence():
         assert len(device) == 2
         assert device[0].pin.number == 2
         assert device[1].pin.number == 3
-        assert device.tuple._fields == ('_0', '_1')
+        assert device._tuple._fields == ('_0', '_1')
 
 def test_composite_device_values():
     with CompositeDevice(
@@ -109,7 +109,7 @@ def test_composite_device_named():
             bar=InputDevice(MockPin(3)),
             _order=('foo', 'bar')
             ) as device:
-        assert device.tuple._fields == ('foo', 'bar')
+        assert device._tuple._fields == ('foo', 'bar')
         assert device.value == (0, 0)
         assert not device.is_active
 


### PR DESCRIPTION
IMHO having a public method called tuple() just makes things too confusing - the first time I saw `self.tuple(some_args)` I automatically assumed it was a typo of just `tuple(some_args)`. And the way it was used in CompositeDevice.value as `return self.tuple(some_args)` when it was defined as being `def tuple(self):` just looks weird. And it's not included in the API documentation either.

I'm not sure I can see a use for it being a public property anyway - why would a user actually want/need to get at the underlying namedtuple type (rather than just relying on whatever the `value` property returns) ?
OTOH if you do want to keep it as a public property (and reject this PR), perhaps it should be renamed to `namedtuple` or `device_tuple_type` and then added to the documentation.