### PR TITLE
Check that the sub-devices of CompositeDevice are actually Device instances

### DIFF
--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -22,6 +22,7 @@ from .exc import (
     CompositeDeviceError,
     CompositeDeviceBadName,
     CompositeDeviceBadOrder,
+    CompositeDeviceBadDevice,
     SPIError,
     SPIBadArgs,
     EnergenieSocketMissing,

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -23,6 +23,7 @@ from .exc import (
     DeviceClosed,
     CompositeDeviceBadName,
     CompositeDeviceBadOrder,
+    CompositeDeviceBadDevice,
     GPIOPinMissing,
     GPIOPinInUse,
     GPIODeviceClosed,
@@ -274,6 +275,9 @@ class CompositeDevice(Device):
         for name in set(self._order) & set(dir(self)):
             raise CompositeDeviceBadName('%s is a reserved name' % name)
         self._all = args + tuple(kwargs[v] for v in self._order)
+        for dev in self._all:
+            if not isinstance(dev, Device):
+                raise CompositeDeviceBadDevice("%s doesn't inherit from Device" % dev)
         self._named = kwargs
         self._tuple = namedtuple('%sValue' % self.__class__.__name__, chain(
             (str(i) for i in range(len(args))), self._order),

--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -31,6 +31,9 @@ class CompositeDeviceBadName(CompositeDeviceError, ValueError):
 class CompositeDeviceBadOrder(CompositeDeviceError, ValueError):
     "Error raised when a composite device is constructed with an incomplete order"
 
+class CompositeDeviceBadDevice(CompositeDeviceError, ValueError):
+    "Error raised when a composite device is constructed with an object that doesn't inherit from :class:`Device`"
+
 class EnergenieSocketMissing(CompositeDeviceError, ValueError):
     "Error raised when socket number is not specified"
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -118,6 +118,10 @@ def test_composite_device_bad_init():
         CompositeDevice(foo=1, bar=2, _order=('foo',))
     with pytest.raises(ValueError):
         CompositeDevice(close=1)
+    with pytest.raises(ValueError):
+        CompositeDevice(2)
+    with pytest.raises(ValueError):
+        CompositeDevice(MockPin(2))
 
 def test_composite_device_read_only():
     device = CompositeDevice(


### PR DESCRIPTION
Not sure if `CompositeDeviceBadDevice` is the best name, so feel free to rename the exception