### PR TITLE
Docs update - Motor is composed of two PWMOutputDevices

### DIFF
--- a/docs/images/composed_devices.dot
+++ b/docs/images/composed_devices.dot
@@ -16,4 +16,5 @@ digraph classes {
     TrafficLightsBuzzer->Button;
 
     Robot->Motor;
+    Motor->PWMOutputDevice;
 }


### PR DESCRIPTION
If this gets merged, I'll leave @waveform80 to do all the image-files creation ;)

Hmmm, and looking at the inheritance graphs on http://gpiozero.readthedocs.org/en/latest/api_output.html#base-classes and http://gpiozero.readthedocs.org/en/latest/api_boards.html#base-classes should the Motor docs be moved from api_output.html to api_boards.html ?