### PR TITLE
Include tests in release source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+recursive-include tests *.py


### PR DESCRIPTION
I'm thinking about packaging gpiozero so it can be included in Debian. It would be great to include the test suite in the pypi tarball so the tests can be run when the Debian package is built.