### PR TITLE
Allow Robot to turn-while-moving

### DIFF
--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -794,27 +794,55 @@ class Robot(SourceMixin, CompositeDevice):
     def value(self, value):
         self.left_motor.value, self.right_motor.value = value
 
-    def forward(self, speed=1):
+    def forward(self, speed=1, curve=0):
         """
         Drive the robot forward by running both motors forward.
 
         :param float speed:
             Speed at which to drive the motors, as a value between 0 (stopped)
             and 1 (full speed). The default is 1.
-        """
-        self.left_motor.forward(speed)
-        self.right_motor.forward(speed)
 
-    def backward(self, speed=1):
+        :param float curve:
+            The amount to curve left (if ``curve`` is less than 0) or curve
+            right (if ``curve`` is greater than 0) while moving forwards, by
+            driving one of the motors at a slower speed. Maximum left curve is
+            -1, maximum right curve is 1. The default is 0 (no curve).
+        """
+        left_speed = speed
+        right_speed = speed
+        if not -1 <= curve <= 1:
+            raise ValueError('curve must be between -1 and 1')
+        if curve < 0:
+            left_speed *= 1 + curve
+        elif curve > 0:
+            right_speed *= 1 - curve
+        self.left_motor.forward(left_speed)
+        self.right_motor.forward(right_speed)
+
+    def backward(self, speed=1, curve=0):
         """
         Drive the robot backward by running both motors backward.
 
         :param float speed:
             Speed at which to drive the motors, as a value between 0 (stopped)
             and 1 (full speed). The default is 1.
+
+        :param float curve:
+            The amount to curve left (if ``curve`` is less than 0) or curve
+            right (if ``curve`` is greater than 0) while moving backwards, by
+            driving one of the motors at a slower speed. Maximum left curve is
+            -1, maximum right curve is 1. The default is 0 (no curve).
         """
-        self.left_motor.backward(speed)
-        self.right_motor.backward(speed)
+        left_speed = speed
+        right_speed = speed
+        if not -1 <= curve <= 1:
+            raise ValueError('curve must be between -1 and 1')
+        if curve < 0:
+            left_speed *= 1 + curve
+        elif curve > 0:
+            right_speed *= 1 - curve
+        self.left_motor.backward(left_speed)
+        self.right_motor.backward(right_speed)
 
     def left(self, speed=1):
         """

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -613,38 +613,134 @@ def test_traffic_hat():
 
 def test_robot():
     pins = [MockPWMPin(n) for n in (2, 3, 4, 5)]
+    def check_pins_and_value(robot, expected_value):
+        if pins[0].state != 0:
+            assert pins[1].state == 0
+        if pins[1].state != 0:
+            assert pins[0].state == 0
+        if pins[2].state != 0:
+            assert pins[3].state == 0
+        if pins[3].state != 0:
+            assert pins[2].state == 0
+        assert (pins[0].state - pins[1].state, pins[2].state - pins[3].state) == expected_value
+        assert robot.value == expected_value
     with Robot((2, 3), (4, 5)) as robot:
         assert (
             [device.pin for device in robot.left_motor] +
             [device.pin for device in robot.right_motor]) == pins
-        assert robot.value == (0, 0)
+        check_pins_and_value(robot, (0, 0))
         robot.forward()
-        assert [pin.state for pin in pins] == [1, 0, 1, 0]
-        assert robot.value == (1, 1)
+        check_pins_and_value(robot, (1, 1))
         robot.backward()
-        assert [pin.state for pin in pins] == [0, 1, 0, 1]
-        assert robot.value == (-1, -1)
+        check_pins_and_value(robot, (-1, -1))
+        robot.forward(0)
+        check_pins_and_value(robot, (0, 0))
         robot.forward(0.5)
-        assert [pin.state for pin in pins] == [0.5, 0, 0.5, 0]
-        assert robot.value == (0.5, 0.5)
-        robot.left()
-        assert [pin.state for pin in pins] == [0, 1, 1, 0]
-        assert robot.value == (-1, 1)
-        robot.right()
-        assert [pin.state for pin in pins] == [1, 0, 0, 1]
-        assert robot.value == (1, -1)
+        check_pins_and_value(robot, (0.5, 0.5))
+        robot.forward(1)
+        check_pins_and_value(robot, (1, 1))
+        robot.forward(1, 0)
+        check_pins_and_value(robot, (1, 1))
+        robot.forward(curve=0)
+        check_pins_and_value(robot, (1, 1))
+        robot.forward(curve=1)
+        check_pins_and_value(robot, (1, 0))
+        robot.forward(curve=-1)
+        check_pins_and_value(robot, (0, 1))
+        robot.forward(0.5, curve=1)
+        check_pins_and_value(robot, (0.5, 0))
+        robot.forward(0.5, curve=-1)
+        check_pins_and_value(robot, (0, 0.5))
+        robot.forward(curve=0.5)
+        check_pins_and_value(robot, (1, 0.5))
+        robot.forward(curve=-0.5)
+        check_pins_and_value(robot, (0.5, 1))
+        robot.forward(0.5, curve=0.5)
+        check_pins_and_value(robot, (0.5, 0.25))
+        robot.forward(0.5, curve=-0.5)
+        check_pins_and_value(robot, (0.25, 0.5))
+        with pytest.raises(ValueError):
+            robot.forward(-1)
+        with pytest.raises(ValueError):
+            robot.forward(2)
+        with pytest.raises(ValueError):
+            robot.forward(curve=-2)
+        with pytest.raises(ValueError):
+            robot.forward(curve=2)
+        robot.backward()
+        check_pins_and_value(robot, (-1, -1))
         robot.reverse()
-        assert [pin.state for pin in pins] == [0, 1, 1, 0]
-        assert robot.value == (-1, 1)
+        check_pins_and_value(robot, (1, 1))
+        robot.backward(0)
+        check_pins_and_value(robot, (0, 0))
+        robot.backward(0.5)
+        check_pins_and_value(robot, (-0.5, -0.5))
+        robot.backward(1)
+        check_pins_and_value(robot, (-1, -1))
+        robot.backward(1, 0)
+        check_pins_and_value(robot, (-1, -1))
+        robot.backward(curve=0)
+        check_pins_and_value(robot, (-1, -1))
+        robot.backward(curve=1)
+        check_pins_and_value(robot, (-1, 0))
+        robot.backward(curve=-1)
+        check_pins_and_value(robot, (0, -1))
+        robot.backward(0.5, curve=1)
+        check_pins_and_value(robot, (-0.5, 0))
+        robot.backward(0.5, curve=-1)
+        check_pins_and_value(robot, (0, -0.5))
+        robot.backward(curve=0.5)
+        check_pins_and_value(robot, (-1, -0.5))
+        robot.backward(curve=-0.5)
+        check_pins_and_value(robot, (-0.5, -1))
+        robot.backward(0.5, curve=0.5)
+        check_pins_and_value(robot, (-0.5, -0.25))
+        robot.backward(0.5, curve=-0.5)
+        check_pins_and_value(robot, (-0.25, -0.5))
+        with pytest.raises(ValueError):
+            robot.backward(-1)
+        with pytest.raises(ValueError):
+            robot.backward(2)
+        with pytest.raises(ValueError):
+            robot.backward(curve=-2)
+        with pytest.raises(ValueError):
+            robot.backward(curve=2)
+        robot.left()
+        check_pins_and_value(robot, (-1, 1))
+        robot.left(0)
+        check_pins_and_value(robot, (0, 0))
+        robot.left(0.5)
+        check_pins_and_value(robot, (-0.5, 0.5))
+        robot.left(1)
+        check_pins_and_value(robot, (-1, 1))
+        with pytest.raises(ValueError):
+            robot.left(-1)
+        with pytest.raises(ValueError):
+            robot.left(2)
+        robot.right()
+        check_pins_and_value(robot, (1, -1))
+        robot.right(0)
+        check_pins_and_value(robot, (0, 0))
+        robot.right(0.5)
+        check_pins_and_value(robot, (0.5, -0.5))
+        robot.right(1)
+        check_pins_and_value(robot, (1, -1))
+        with pytest.raises(ValueError):
+            robot.right(-1)
+        with pytest.raises(ValueError):
+            robot.right(2)
+        robot.reverse()
+        check_pins_and_value(robot, (-1, 1))
         robot.stop()
-        assert [pin.state for pin in pins] == [0, 0, 0, 0]
-        assert robot.value == (0, 0)
+        check_pins_and_value(robot, (0, 0))
+        robot.stop()
+        check_pins_and_value(robot, (0, 0))
         robot.value = (-1, -1)
-        assert robot.value == (-1, -1)
+        check_pins_and_value(robot, (-1, -1))
         robot.value = (0.5, 1)
-        assert robot.value == (0.5, 1)
+        check_pins_and_value(robot, (0.5, 1))
         robot.value = (0, -0.5)
-        assert robot.value == (0, -0.5)
+        check_pins_and_value(robot, (0, -0.5))
 
 def test_ryanteck_robot():
     pins = [MockPWMPin(n) for n in (17, 18, 22, 23)]


### PR DESCRIPTION
by adding an optional `curve` parameter to the forward() and backward() methods.

I also added a few more Robot test-cases while I was at it ;-)
