### PR TITLE
Typo in SPISoftwareBus._shared_key

### DIFF
--- a/gpiozero/spi.py
+++ b/gpiozero/spi.py
@@ -163,7 +163,7 @@ class SPISoftwareBus(SharedMixin, Device):
         return self.lock is None
 
     @classmethod
-    def _shared_key(self, clock_pin, mosi_pin, miso_pin):
+    def _shared_key(cls, clock_pin, mosi_pin, miso_pin):
         return (clock_pin, mosi_pin, miso_pin)
 
     def read(self, n):


### PR DESCRIPTION
It's a `@classmethod`, so the first parameter is cls not self