### PR TITLE
Always make PWMOutputDevice operate on floats.

### DIFF
--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -376,9 +376,12 @@ class GPIODevice(Device):
         self._active_state = True
         self._inactive_state = False
 
+    def _state_to_value(self, state):
+        return bool(state == self._active_state)
+
     def _read(self):
         try:
-            return self.pin.state == self._active_state
+            return self._state_to_value(self.pin.state)
         except (AttributeError, TypeError):
             self._check_open()
             raise


### PR DESCRIPTION
Before this patch, the following script:
```python
from gpiozero.pins.mock import MockPin, MockPWMPin
from gpiozero import DigitalOutputDevice, PWMOutputDevice
PinClass = MockPWMPin
for DeviceClass in (DigitalOutputDevice, PWMOutputDevice):
    print(DeviceClass)
    pins = []
    pins.append(DeviceClass(PinClass(2)))
    pins.append(DeviceClass(PinClass(3), initial_value=False))
    pins.append(DeviceClass(PinClass(4), initial_value=0))
    pins.append(DeviceClass(PinClass(5), initial_value=0.0))
    pins.append(DeviceClass(PinClass(6), active_high=False))
    pins.append(DeviceClass(PinClass(7), active_high=False, initial_value=False))
    pins.append(DeviceClass(PinClass(8), active_high=False, initial_value=0))
    pins.append(DeviceClass(PinClass(9), active_high=False, initial_value=0.0))
    print([x.value for x in pins])
    for value in (False, 0, 0.0, True, 1, 1.0):
        pins[0].value = value
        pins[4].value = value
        print([x.value for x in (pins[0], pins[4])])
    for pin in pins:
        pin.close()
    MockPin.clear_pins()
```
results in:
```
<class 'gpiozero.output_devices.DigitalOutputDevice'>
[False, False, False, False, False, False, False, False]
[False, False]
[False, False]
[False, False]
[True, True]
[True, True]
[True, True]
<class 'gpiozero.output_devices.PWMOutputDevice'>
[False, False, False, False, 0.0, 0.0, 0.0, 0.0]
[False, 0.0]
[False, 0.0]
[False, 0.0]
[1.0, 1.0]
[1.0, 1.0]
[1.0, 1.0]
```

whereas after this patch, the same script results in:
```
<class 'gpiozero.output_devices.DigitalOutputDevice'>
[False, False, False, False, False, False, False, False]
[False, False]
[False, False]
[False, False]
[True, True]
[True, True]
[True, True]
<class 'gpiozero.output_devices.PWMOutputDevice'>
[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
[0.0, 0.0]
[0.0, 0.0]
[0.0, 0.0]
[1.0, 1.0]
[1.0, 1.0]
[1.0, 1.0]
```
which IMHO is much more consistent. This is sort-of a move in the same direction as #212 

While I was at it, I also added better 'encapsulation' of the active_high properties of both OutputDevice and PWMOutputDevice, and I made a small tweak to the init-method of PWMOutputDevice.