### PR TITLE
Don't (implicitly) set an initial_value in PWMOutputDevice's init method via the super() call

### DIFF
--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -299,7 +299,7 @@ class PWMOutputDevice(OutputDevice):
         self._controller = None
         if not 0 <= initial_value <= 1:
             raise OutputDeviceBadValue("initial_value must be between 0 and 1")
-        super(PWMOutputDevice, self).__init__(pin, active_high)
+        super(PWMOutputDevice, self).__init__(pin, active_high, initial_value=None)
         try:
             # XXX need a way of setting these together
             self.pin.frequency = frequency


### PR DESCRIPTION
fixes #326  (which is a bug that got introduced with #324)

Unfortunately we can't add a unit-test for this, due to the problems with multiple PWM tests causing segfaults (which is something I'm also very close to fixing).