### PR TITLE
Remove redundant line of code

### DIFF
--- a/gpiozero/spi_devices.py
+++ b/gpiozero/spi_devices.py
@@ -112,7 +112,6 @@ class MCP3xxx(AnalogInputDevice):
 
     def __init__(self, channel=0, bits=10, differential=False, **spi_args):
         self._channel = channel
-        self._bits = bits
         self._differential = bool(differential)
         super(MCP3xxx, self).__init__(bits, **spi_args)
 


### PR DESCRIPTION
self._bits is already set in AnalogInputDevice so no need to also set it in MCP3xxx