### PR TITLE
Doc tweak

### DIFF
--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -50,7 +50,7 @@ class InputDevice(GPIODevice):
     def pull_up(self):
         """
         If ``True``, the device uses a pull-up resistor to set the GPIO pin
-        "high" by default. Defaults to ``False``.
+        "high" by default.
         """
         return self.pin.pull == 'up'
 


### PR DESCRIPTION
The default value should only be documented for the init-method, not on the property itself.

The current state means that http://gpiozero.readthedocs.io/en/latest/api_input.html#gpiozero.Button says pull_up defaults to True, but http://gpiozero.readthedocs.io/en/latest/api_input.html#gpiozero.Button.pull_up says pull_up defaults to False!