### PR TITLE
Add optional enable init param to motor, close #366

### DIFF
--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -814,7 +814,7 @@ class Motor(SourceMixin, CompositeDevice):
                 'forward and backward pins must be provided'
             )
         PinClass = PWMOutputDevice if pwm else DigitalOutputDevice
-        if enable:
+        if enable is not None:
             super(Motor, self).__init__(
                 forward_device=PinClass(forward),
                 backward_device=PinClass(backward),


### PR DESCRIPTION
(_Not complete yet, needs checking over and documenting_)

This PR adds a third (optional) pin parameter to `Motor`'s init. If provided, a `DigitalOutputDevice` is created (initially set high, and untouched elsewhere) and added to the list of devices.

As per #366.
