### PR TITLE
Use PIGPIO_ADDR and PIGPIO_PORT environment variable if they exist to…

### DIFF
--- a/gpiozero/pins/pigpiod.py
+++ b/gpiozero/pins/pigpiod.py
@@ -99,7 +99,7 @@ class PiGPIOPin(Pin):
     GPIO_PULL_UP_NAMES = {v: k for (k, v) in GPIO_PULL_UPS.items()}
     GPIO_EDGES_NAMES = {v: k for (k, v) in GPIO_EDGES.items()}
 
-    def __new__(cls, number, host=os.getenv("PIGPIO_ADDR", 'localhost'), port=os.getenv("PIGPIO_PORT", 8888)):
+    def __new__(cls, number, host=os.getenv('PIGPIO_ADDR', 'localhost'), port=int(os.getenv('PIGPIO_PORT', 8888))):
         try:
             return cls._PINS[(host, port, number)]
         except KeyError:

--- a/gpiozero/pins/pigpiod.py
+++ b/gpiozero/pins/pigpiod.py
@@ -8,6 +8,7 @@ str = type('')
 
 import warnings
 import pigpio
+import os
 
 from . import Pin
 from .data import pi_info
@@ -98,7 +99,7 @@ class PiGPIOPin(Pin):
     GPIO_PULL_UP_NAMES = {v: k for (k, v) in GPIO_PULL_UPS.items()}
     GPIO_EDGES_NAMES = {v: k for (k, v) in GPIO_EDGES.items()}
 
-    def __new__(cls, number, host='localhost', port=8888):
+    def __new__(cls, number, host=os.getenv("PIGPIO_ADDR", 'localhost'), port=os.getenv("PIGPIO_PORT", 8888)):
         try:
             return cls._PINS[(host, port, number)]
         except KeyError:


### PR DESCRIPTION
… configure PiGPIO, otherwise it use the default value 'localhost' and 8888. This is the same behaviour as the pigpio library for initialisation.

See #353 for more explanation.

This is the PiGPIO part of #356 and it follow the remark from @lurch about space around "=".
The environmental variable for selecting the pin factory will be in a separate pull request.
The typo has already been fixed by @bennuttall 