### PR TITLE
Read GPIOZERO_PIN_FACTORY environement variable fix #359

### DIFF
--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -61,8 +61,10 @@ try:
             from .pins.mock import MockPWMPin
             pin_factory = MockPWMPin
         else:
+            pass
 #            print ("Valid value for GPIOZERO_PIN_FACTORY are: 'RPiGPIOPin' 'RPIOPin' 'PiGPIOPin' 'NativePin' 'MockPin' 'MockPWMPin'")
 except ImportError:
+    pass
 #    print ("Failure to import requested pin factory requested by GPIOZERO_PIN_FACTORY. Using default fallback sequence.")
 
 if pin_factory is None:

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -7,6 +7,7 @@ from __future__ import (
 nstr = str
 str = type('')
 
+import os
 import atexit
 import weakref
 from collections import namedtuple
@@ -35,20 +36,50 @@ from .compat import frozendict
 # available, however, we fall back to a pure Python implementation which
 # supports platforms like PyPy
 from .pins import _pins_shutdown
+
+pin_factory = None
+env_default = os.getenv('GPIOZERO_PIN_FACTORY', None)
+
 try:
-    from .pins.rpigpio import RPiGPIOPin
-    pin_factory = RPiGPIOPin
-except ImportError:
-    try:
-        from .pins.rpio import RPIOPin
-        pin_factory = RPIOPin
-    except ImportError:
-        try:
+    if env_default is not None:
+        if env_default == 'RPiGPIOPin':
+            from .pins.rpigpio import RPiGPIOPin
+            pin_factory = RPiGPIOPin
+        elif env_default == 'RPIOPin':
+            from .pins.rpio import RPIOPin
+            pin_factory = RPIOPin
+        elif env_default == 'PiGPIOPin':
             from .pins.pigpiod import PiGPIOPin
             pin_factory = PiGPIOPin
-        except ImportError:
+        elif env_default == 'NativePin':
             from .pins.native import NativePin
             pin_factory = NativePin
+        elif env_default == 'MockPin':
+            from .pins.mock import MockPin
+            pin_factory = MockPin
+        elif env_default == 'MockPWMPin':
+            from .pins.mock import MockPWMPin
+            pin_factory = MockPWMPin
+        else:
+#            print ("Valid value for GPIOZERO_PIN_FACTORY are: 'RPiGPIOPin' 'RPIOPin' 'PiGPIOPin' 'NativePin' 'MockPin' 'MockPWMPin'")
+except ImportError:
+#    print ("Failure to import requested pin factory requested by GPIOZERO_PIN_FACTORY. Using default fallback sequence.")
+
+if pin_factory is None:
+    try:
+        from .pins.rpigpio import RPiGPIOPin
+        pin_factory = RPiGPIOPin
+    except ImportError:
+        try:
+            from .pins.rpio import RPIOPin
+            pin_factory = RPIOPin
+        except ImportError:
+            try:
+                from .pins.pigpiod import PiGPIOPin
+                pin_factory = PiGPIOPin
+            except ImportError:
+                from .pins.native import NativePin
+                pin_factory = NativePin
 
 
 _PINS = set()


### PR DESCRIPTION
Accept the value 'RPiGPIOPin', 'RPIOPin', 'PiGPIOPin', 'NativePin', 'MockPin' and 'MockPWMPin'.
In case of failure to import the requested pin factory, it use the default fallback sequence.

This is the ENV selection of pin factory part of #356 and it try to follow the remark from @lurch about indentation and not using print. However it does not do warning (suggestion to use https://docs.python.org/2/library/warnings.html).
