### PR TITLE
Fix #354, fix #389

### DIFF
--- a/docs/api_pins.rst
+++ b/docs/api_pins.rst
@@ -37,28 +37,21 @@ You can change the default pin implementation by over-writing the
     # This will now use NativePin instead of RPiGPIOPin
     led = LED(16)
 
-``pin_factory`` is simply a callable that accepts a single argument: the number
-of the pin to be constructed (this prototype *may* be expanded in future). This
-means you can define it as a function that provides additional parameters to an
-underlying class. For example, to default to creating pins with
-:class:`gpiozero.pins.pigpiod.PiGPIOPin` on a remote pi called ``remote-pi``::
+``pin_factory`` is a concrete descendent of the abstract :class:`Pin` class.
+The descendent may take additional parameters in its constructor provided they
+are optional; GPIO Zero will expect to be able to construct instances with
+nothing more than an integer pin number.
 
-    from gpiozero.pins.pigpiod import PiGPIOPin
-    import gpiozero.devices
+However, the descendent may take default information from additional sources.
+For example, to default to creating pins with
+:class:`gpiozero.pins.pigpiod.PiGPIOPin` on a remote pi called ``remote-pi``
+you can set the :envvar:`PIGPIO_ADDR` environment variable when running your
+script::
 
-    def my_pin_factory(number):
-        return PiGPIOPin(number, host='remote-pi')
+    $ PIGPIO_ADDR=remote-pi python my_script.py
 
-    gpiozero.devices.pin_factory = my_pin_factory
-
-    from gpiozero import TrafficLights
-
-    # This will now use pins on remote-pi (assuming it has the
-    # pigpiod daemon installed and running)
-    tl = TrafficLights(13, 19, 26)
-
-Alternatively, instead of passing an integer to the device constructor, you
-can pass an object derived from :class:`Pin` itself::
+It is worth noting that instead of passing an integer to device constructors,
+you can pass an object derived from :class:`Pin` itself::
 
     from gpiozero.pins.native import NativePin
     from gpiozero import LED
@@ -118,6 +111,13 @@ Abstract Pin
 ============
 
 .. autoclass:: Pin
+    :members:
+
+
+Local Pin
+=========
+
+.. autoclass:: LocalPin
     :members:
 
 

--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -7,6 +7,7 @@ from __future__ import (
 
 from .pins import (
     Pin,
+    LocalPin,
 )
 from .pins.data import (
     PiBoardInfo,

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -16,6 +16,7 @@ except ImportError:
     from ..compat import isclose
 
 from . import Pin
+from .data import pi_info
 from ..exc import PinSetInput, PinPWMUnsupported, PinFixedPull
 
 
@@ -31,6 +32,10 @@ class MockPin(Pin):
     @classmethod
     def clear_pins(cls):
         cls._PINS.clear()
+
+    @classmethod
+    def pi_info(cls):
+        return pi_info('a21041') # Pretend we're a Pi 2B
 
     def __new__(cls, number):
         if not (0 <= number < 54):

--- a/gpiozero/pins/native.py
+++ b/gpiozero/pins/native.py
@@ -17,7 +17,7 @@ from time import sleep
 from threading import Thread, Event, Lock
 from collections import Counter
 
-from . import Pin, PINS_CLEANUP
+from . import LocalPin, PINS_CLEANUP
 from .data import pi_info
 from ..exc import (
     PinInvalidPull,
@@ -149,7 +149,7 @@ class GPIOFS(object):
                     f.write(str(pin).encode('ascii'))
 
 
-class NativePin(Pin):
+class NativePin(LocalPin):
     """
     Uses a built-in pure Python implementation to interface to the Pi's GPIO
     pins. This is the default pin implementation if no third-party libraries

--- a/gpiozero/pins/rpigpio.py
+++ b/gpiozero/pins/rpigpio.py
@@ -9,7 +9,7 @@ str = type('')
 import warnings
 from RPi import GPIO
 
-from . import Pin
+from . import LocalPin
 from .data import pi_info
 from ..exc import (
     PinInvalidFunction,
@@ -24,7 +24,7 @@ from ..exc import (
     )
 
 
-class RPiGPIOPin(Pin):
+class RPiGPIOPin(LocalPin):
     """
     Uses the `RPi.GPIO`_ library to interface to the Pi's GPIO pins. This is
     the default pin implementation if the RPi.GPIO library is installed.

--- a/gpiozero/pins/rpio.py
+++ b/gpiozero/pins/rpio.py
@@ -12,7 +12,7 @@ import RPIO
 import RPIO.PWM
 from RPIO.Exceptions import InvalidChannelException
 
-from . import Pin, PINS_CLEANUP
+from . import LocalPin, PINS_CLEANUP
 from .data import pi_info
 from ..exc import (
     PinInvalidFunction,
@@ -27,7 +27,7 @@ from ..exc import (
     )
 
 
-class RPIOPin(Pin):
+class RPIOPin(LocalPin):
     """
     Uses the `RPIO`_ library to interface to the Pi's GPIO pins. This is
     the default pin implementation if the RPi.GPIO library is not installed,

--- a/tests/test_pins_data.py
+++ b/tests/test_pins_data.py
@@ -1,0 +1,90 @@
+from __future__ import (
+    unicode_literals,
+    absolute_import,
+    print_function,
+    division,
+    )
+str = type('')
+
+
+import pytest
+from mock import patch, MagicMock
+
+import gpiozero.devices
+import gpiozero.pins.data
+import gpiozero.pins.native
+from gpiozero.pins.data import pi_info
+from gpiozero import PinMultiplePins, PinNoPins, PinUnknownPi
+
+
+def test_pi_revision():
+    save_factory = gpiozero.devices.pin_factory
+    try:
+        # Can't use MockPin for this as we want something that'll actually try
+        # and read /proc/cpuinfo (MockPin simply parrots the 2B's data);
+        # NativePin is used as we're guaranteed to be able to import it
+        gpiozero.devices.pin_factory = gpiozero.pins.native.NativePin
+        with patch('io.open') as m:
+            m.return_value.__enter__.return_value = ['lots of irrelevant', 'lines', 'followed by', 'Revision: 0002', 'Serial:  xxxxxxxxxxx']
+            assert pi_info().revision == '0002'
+            # LocalPin caches the revision (because realistically it isn't going to
+            # change at runtime); we need to wipe it here though
+            gpiozero.pins.native.NativePin._PI_REVISION = None
+            m.return_value.__enter__.return_value = ['Revision: a21042']
+            assert pi_info().revision == 'a21042'
+            # Check over-volting result (some argument over whether this is 7 or
+            # 8 character result; make sure both work)
+            gpiozero.pins.native.NativePin._PI_REVISION = None
+            m.return_value.__enter__.return_value = ['Revision: 1000003']
+            assert pi_info().revision == '0003'
+            gpiozero.pins.native.NativePin._PI_REVISION = None
+            m.return_value.__enter__.return_value = ['Revision: 100003']
+            assert pi_info().revision == '0003'
+            with pytest.raises(PinUnknownPi):
+                m.return_value.__enter__.return_value = ['nothing', 'relevant', 'at all']
+                gpiozero.pins.native.NativePin._PI_REVISION = None
+                pi_info()
+            with pytest.raises(PinUnknownPi):
+                pi_info('0fff')
+    finally:
+        gpiozero.devices.pin_factory = save_factory
+
+def test_pi_info():
+    r = pi_info('900011')
+    assert r.model == 'B'
+    assert r.pcb_revision == '1.0'
+    assert r.memory == 512
+    assert r.manufacturer == 'Sony'
+    assert r.storage == 'SD'
+    assert r.usb == 2
+    assert not r.wifi
+    assert not r.bluetooth
+    assert r.csi == 1
+    assert r.dsi == 1
+    with pytest.raises(PinUnknownPi):
+        pi_info('9000f1')
+
+def test_pi_info_other_types():
+    with pytest.raises(PinUnknownPi):
+        pi_info(b'9000f1')
+    with pytest.raises(PinUnknownPi):
+        pi_info(0x9000f1)
+
+def test_physical_pins():
+    # Assert physical pins for some well-known Pi's; a21041 is a Pi2B
+    assert pi_info('a21041').physical_pins('3V3') == {('P1', 1), ('P1', 17)}
+    assert pi_info('a21041').physical_pins('GPIO2') == {('P1', 3)}
+    assert pi_info('a21041').physical_pins('GPIO47') == set()
+
+def test_physical_pin():
+    with pytest.raises(PinMultiplePins):
+        assert pi_info('a21041').physical_pin('GND')
+    assert pi_info('a21041').physical_pin('GPIO3') == ('P1', 5)
+    with pytest.raises(PinNoPins):
+        assert pi_info('a21041').physical_pin('GPIO47')
+
+def test_pulled_up():
+    assert pi_info('a21041').pulled_up('GPIO2')
+    assert not pi_info('a21041').pulled_up('GPIO4')
+    assert not pi_info('a21041').pulled_up('GPIO47')
+


### PR DESCRIPTION
Overhaul the pi_info system:

Pin factories are now capable of generating pi_info themselves (although
currently they all just look up the revision and call pi_info with a
specific one).

PiGPIOPin will now return pi_info for the remote pi which can be
specified by parameter or implicitly by the environment vars.

Overvolted Pis should work properly no matter what (some argument over
whether the revision 7 or 8 chars in this case; both should work). Added
some minor tweaks for the new camera-capable Pi Zero

Finally, added a bunch of tests for pins.data