### PR TITLE
Include documentation in sdist pypi release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include README.rst
 recursive-include tests *.py
+recursive-include docs Makefile *.py *.rst
+recursive-include docs/images *


### PR DESCRIPTION
I'm thinking about uploading gpiozero to Debian and I'd like to include the documentation.

Debian packages tend to be based on the pypi release, so I've changed the manifest to included it when setup.py sdist is run.

Other uses of the pypi release will probably find it helpful to have the documentation and examples.