### PR TITLE
Use tox to run test and manage test dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ python:
     - "2.7"
     - "pypy"
     - "pypy3"
-install: "pip install -e .[test]"
+install: 
+    - pip install tox-travis
 script: make test
 before_install:
-    # Coverage 4.0 no longer supports py3.2 and codecov depends on latest coverage
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install "coverage<4.0dev"; fi
     - pip install codecov
 after_success:
     - codecov

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 # External utilities
 PYTHON=python
 PIP=pip
-PYTEST=py.test
-COVERAGE=coverage
+TOX=tox
 PYFLAGS=
 DEST_DIR=/
 
@@ -101,8 +100,7 @@ develop: tags
 	$(PIP) install -e .[doc,test]
 
 test:
-	$(COVERAGE) run -m $(PYTEST) tests -v
-	$(COVERAGE) report --rcfile coverage.cfg
+	$(TOX)
 
 clean:
 	$(PYTHON) $(PYFLAGS) setup.py clean
@@ -138,7 +136,7 @@ $(DIST_DEB): $(PY_SOURCES) $(SUBDIRS) $(DEB_SOURCES) $(MAN_PAGES)
 	# project_version.orig.tar.gz
 	$(PYTHON) $(PYFLAGS) setup.py sdist --dist-dir=../
 	rename -f 's/$(NAME)-(.*)\.tar\.gz/$(NAME)_$$1\.orig\.tar\.gz/' ../*
-	debuild -b -i -I -Idist -Ibuild -Idocs/_build -Icoverage -I__pycache__ -I.coverage -Itags -I*.pyc -I*.vim -I*.xcf -rfakeroot
+	debuild -b -i -I -Idist -Ibuild -Idocs/_build -I.tox -I__pycache__ -Itags -I*.pyc -I*.vim -I*.xcf -rfakeroot
 	mkdir -p dist/
 	for f in $(DIST_DEB); do cp ../$${f##*/} dist/; done
 
@@ -147,7 +145,7 @@ $(DIST_DSC): $(PY_SOURCES) $(SUBDIRS) $(DEB_SOURCES) $(MAN_PAGES)
 	# project_version.orig.tar.gz
 	$(PYTHON) $(PYFLAGS) setup.py sdist --dist-dir=../
 	rename -f 's/$(NAME)-(.*)\.tar\.gz/$(NAME)_$$1\.orig\.tar\.gz/' ../*
-	debuild -S -i -I -Idist -Ibuild -Idocs/_build -Icoverage -I__pycache__ -I.coverage -Itags -I*.pyc -I*.vim -I*.xcf -rfakeroot
+	debuild -S -i -I -Idist -Ibuild -Idocs/_build -I.tox -I__pycache__ -Itags -I*.pyc -I*.vim -I*.xcf -rfakeroot
 	mkdir -p dist/
 	for f in $(DIST_DSC); do cp ../$${f##*/} dist/; done
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+coverage==4.2
+mock==2.0.0
+pytest==3.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist =
+	py27,
+	py32,
+	py33,
+	py34,
+	py35,
+	pypy,
+	pypy3,
+
+[testenv]
+deps =
+	-r{toxinidir}/requirements-test.txt
+	py32: coverage<4.0dev
+commands =
+	{envbindir}/coverage run -m py.test tests -v
+	{envbindir}/coverage report --rcfile coverage.cfg


### PR DESCRIPTION
- Explicit test dependencies with version pinning
- Automatic virtualenv management

(Does introduce an implicit tox dependency for contributors!)
