### PR TITLE
Fix AttributeError exceptions when Exceptions are raised during __init__

### DIFF
--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -205,7 +205,6 @@ class LEDCollection(CompositeOutputDevice):
     :class:`LEDBoard` and :class:`LEDBarGraph`.
     """
     def __init__(self, *args, **kwargs):
-        self._blink_thread = None
         pwm = kwargs.pop('pwm', False)
         active_high = kwargs.pop('active_high', True)
         initial_value = kwargs.pop('initial_value', False)
@@ -291,6 +290,7 @@ class LEDBoard(LEDCollection):
         create trees of LEDs.
     """
     def __init__(self, *args, **kwargs):
+        self._blink_thread = None
         self._blink_leds = []
         self._blink_lock = Lock()
         super(LEDBoard, self).__init__(*args, **kwargs)
@@ -1139,6 +1139,7 @@ class Energenie(SourceMixin, Device):
     """
 
     def __init__(self, socket=None, initial_value=False):
+        self._master = None
         if socket is None:
             raise EnergenieSocketMissing('socket number must be provided')
         if not (1 <= socket <= 4):

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -340,7 +340,8 @@ class CompositeDevice(Device):
     def close(self):
         if self._all:
             for device in self._all:
-                device.close()
+                if isinstance(device, Device):
+                    device.close()
 
     @property
     def closed(self):

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -573,9 +573,9 @@ class DistanceSensor(SmoothedInputDevice):
     def __init__(
             self, echo=None, trigger=None, queue_len=30, max_distance=1,
             threshold_distance=0.3, partial=False):
+        self._trigger = None
         if max_distance <= 0:
             raise ValueError('invalid maximum distance (must be positive)')
-        self._trigger = None
         super(DistanceSensor, self).__init__(
             echo, pull_up=False, threshold=threshold_distance / max_distance,
             queue_len=queue_len, sample_wait=0.0, partial=partial
@@ -611,7 +611,13 @@ class DistanceSensor(SmoothedInputDevice):
                 raise
         else:
             self._trigger = None
-        super(DistanceSensor, self).close()
+
+        # need to catch AttributeError here, in case exception is raised
+        # inside __init__ before the parent __init__ is called
+        try:
+            super(DistanceSensor, self).close()
+        except AttributeError:
+            pass
 
     @property
     def max_distance(self):


### PR DESCRIPTION
Prevents the `Exception AttributeError: "'XXXXXXXX' object has no attribute
'YYYYYYYY'" in  ignored` messages which sometimes pop up when running the
unit tests.
