### PR TITLE
Add pinout.py command-line tool, close #444

### DIFF
--- a/docs/cli_pinout.rst
+++ b/docs/cli_pinout.rst
@@ -1,0 +1,26 @@
+==================
+Command-line Tools
+==================
+
+Pinout
+======
+
+The gpiozero package contains a database of information about the various
+revisions of Raspberry Pi. This is queried by the ``pinout`` command-line
+tool to write details of the GPIO pins available.
+
+Unless specified, the revision of the current device will be detected. A
+particular revision may be selected with the --revision command-line
+option. *e.g.*:
+
+    pinout.py --revision 000d
+
+By default, the output will include ANSI color codes if run in a color-capable
+terminal. This behaviour may be overridden by the --color or --monochrome
+options to force colored or non-colored output, respectively. *e.g.*:
+
+    pinout.py --monochrome
+
+Full usage details are available with:
+
+    pinout.py --help

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Table of Contents
     api_tools
     api_pins
     api_exc
+    cli_pinout
     changelog
     license
 

--- a/gpiozero/cli/pinout.py
+++ b/gpiozero/cli/pinout.py
@@ -56,7 +56,7 @@ def main():
         try:
             pi_info().pprint(color=args.color)
         except IOError:
-            print('This device is not an Raspberry Pi?')
+            print('This device is not a Raspberry Pi?')
             exit(2)
     else:
         pi_info(args.revision).pprint(color=args.color)

--- a/gpiozero/cli/pinout.py
+++ b/gpiozero/cli/pinout.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""
+pinout.py - gpiozero command-line pinout tool.
+
+Output Raspberry Pi GPIO pinout information.
+"""
+
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import argparse
+import sys
+
+from gpiozero import *
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser(
+        description=__doc__
+    )
+
+    parser.add_argument(
+        '-r', '--revision',
+        dest='revision',
+        default='',
+        help='RPi revision. Default is to autodetect revision of current device'
+    )
+
+    parser.add_argument(
+        '-c', '--color',
+        action="store_true",
+        default=None,
+        help='Force colored output (by default, the output will include ANSI'
+        'color codes if run in a color-capable terminal). See also --monochrome'
+    )
+
+    parser.add_argument(
+        '-m', '--monochrome',
+        dest='color',
+        action='store_false',
+        help='Force monochrome output. See also --color'
+    )
+
+    try:
+        args = parser.parse_args(args)
+    except argparse.ArgumentError as ex:
+        print('Error parsing arguments.')
+        parser.error(str(ex.message))
+        exit(-1)
+    return args
+
+
+def main():
+    args = parse_args(sys.argv[1:])
+
+    if args.revision == '':
+        try:
+            pi_info().pprint(color=args.color)
+        except IOError:
+            print('This device is not an Raspberry Pi?')
+            exit(2)
+    else:
+        pi_info(args.revision).pprint(color=args.color)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/cli/test_pinout.py
+++ b/tests/cli/test_pinout.py
@@ -1,0 +1,40 @@
+from __future__ import (
+    unicode_literals,
+    absolute_import,
+    print_function,
+    division,
+    )
+str = type('')
+
+
+import pytest
+
+import cli.pinout as pinout
+
+
+def test_args_incorrect():
+    with pytest.raises(SystemExit) as ex:
+        pinout.parse_args(['--nonexistentarg'])
+    assert ex.value.code == 2
+
+
+def test_args_color():
+    args = pinout.parse_args([])
+    assert args.color is None
+    args = pinout.parse_args(['--color'])
+    assert args.color is True
+    args = pinout.parse_args(['--monochrome'])
+    assert args.color is False
+
+
+def test_args_revision():
+    args = pinout.parse_args(['--revision', '000d'])
+    assert args.revision == '000d'
+
+
+def test_help(capsys):
+    with pytest.raises(SystemExit) as ex:
+        pinout.parse_args(['--help'])
+    out, err = capsys.readouterr()
+    assert 'GPIO pinout' in out
+    assert ex.value.code == 0

--- a/tests/cli/test_pinout.py
+++ b/tests/cli/test_pinout.py
@@ -9,7 +9,7 @@ str = type('')
 
 import pytest
 
-import cli.pinout as pinout
+import gpiozero.cli.pinout as pinout
 
 
 def test_args_incorrect():


### PR DESCRIPTION
Add a "pinout" command-line tool which will write information about GPIO pins for the various RPi revisions.

This corresponds to issue #444.