### PR TITLE
Make close() nethods more exception-safe

### DIFF
--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -338,9 +338,10 @@ class CompositeDevice(Device):
         return self._all
 
     def close(self):
-        if self._all:
+        if getattr(self, '_all', None):
             for device in self._all:
-                device.close()
+                if isinstance(device, Device):
+                    device.close()
 
     @property
     def closed(self):
@@ -403,11 +404,12 @@ class GPIODevice(Device):
     def close(self):
         super(GPIODevice, self).close()
         with _PINS_LOCK:
-            pin = self._pin
-            self._pin = None
-            if pin in _PINS:
-                _PINS.remove(pin)
-                pin.close()
+            if hasattr(self, '_pin'):
+                pin = self._pin
+                self._pin = None
+                if pin in _PINS:
+                    _PINS.remove(pin)
+                    pin.close()
 
     @property
     def closed(self):

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -142,7 +142,8 @@ class SmoothedInputDevice(EventsMixin, InputDevice):
 
     def close(self):
         try:
-            self._queue.stop()
+            if hasattr(self, '_queue'):
+                self._queue.stop()
         except AttributeError:
             # If the queue isn't initialized (it's None) ignore the error
             # because we're trying to close anyway
@@ -605,7 +606,8 @@ class DistanceSensor(SmoothedInputDevice):
 
     def close(self):
         try:
-            self._trigger.close()
+            if hasattr(self, '_trigger'):
+                self._trigger.close()
         except AttributeError:
             if self._trigger is not None:
                 raise

--- a/gpiozero/mixins.py
+++ b/gpiozero/mixins.py
@@ -105,7 +105,7 @@ class SourceMixin(object):
 
     @source.setter
     def source(self, value):
-        if self._source_thread is not None:
+        if getattr(self, '_source_thread', None):
             self._source_thread.stop()
             self._source_thread = None
         self._source = value
@@ -340,7 +340,7 @@ class HoldMixin(EventsMixin):
         self._hold_thread = HoldThread(self)
 
     def close(self):
-        if self._hold_thread:
+        if getattr(self, '_hold_thread', None):
             self._hold_thread.stop()
             self._hold_thread = None
         try:

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -181,10 +181,10 @@ class DigitalOutputDevice(OutputDevice):
             self._blink_thread = None
 
     def _stop_blink(self):
-        if self._controller:
+        if getattr(self, '_controller', None):
             self._controller._stop_blink(self)
             self._controller = None
-        if self._blink_thread:
+        if getattr(self, '_blink_thread', None):
             self._blink_thread.stop()
             self._blink_thread = None
 
@@ -570,7 +570,7 @@ class RGBLED(SourceMixin, Device):
     blue = _led_property(2)
 
     def close(self):
-        if self._leds:
+        if getattr(self, '_leds', None):
             self._stop_blink()
             for led in self._leds:
                 led.close()

--- a/gpiozero/spi.py
+++ b/gpiozero/spi.py
@@ -43,7 +43,7 @@ class SPIHardwareInterface(Device):
         self._device.max_speed_hz = 500000
 
     def close(self):
-        if self._device:
+        if getattr(self, '_device', None):
             try:
                 self._device.close()
             finally:
@@ -142,7 +142,7 @@ class SPISoftwareBus(SharedMixin, Device):
 
     def close(self):
         super(SPISoftwareBus, self).close()
-        if self.lock:
+        if getattr(self, 'lock', None):
             with self.lock:
                 if self.miso is not None:
                     self.miso.close()
@@ -205,7 +205,7 @@ class SPISoftwareInterface(OutputDevice):
             raise
 
     def close(self):
-        if self._bus:
+        if getattr(self, '_bus', None):
             self._bus.close()
             self._bus = None
         super(SPISoftwareInterface, self).close()

--- a/gpiozero/spi_devices.py
+++ b/gpiozero/spi_devices.py
@@ -31,7 +31,7 @@ class SPIDevice(Device):
         self._spi = SPI(**spi_args)
 
     def close(self):
-        if self._spi:
+        if getattr(self, '_spi', None):
             s = self._spi
             self._spi = None
             s.close()


### PR DESCRIPTION
If an exception is thrown during init, it's possible for a close() method (or
one of the methods called by close) to try accessing an attribute that hasn't
been created yet, which would throw an AttributeError exception. This commit
fixes that by ensuring that the close() methods (and methods called by them)
always use hasattr() or getattr() first, before trying to access the
attributes directly.

Fixes #503 and supersedes #494