### PR TITLE
add GPIOZeroWarning.printWarnings. 

### DIFF
--- a/docs/api_exc.rst
+++ b/docs/api_exc.rst
@@ -33,6 +33,17 @@ so you can still do::
     except ValueError:
         print('Bad value specified')
 
+All of GPIO Zero's warnings descend from :exc:`GPIOZeroWarning`. The GPIO Zero
+warnings are used when printing a warning message using `warnings.warn()`. The
+:exc:`GPIOZeroWarning` class defines a single data member: `printWarnings`, which
+is tested before calling `warnings.warn()`, allowing you to turn off the
+warning messages on a per-class basis::
+
+    from gpiozero import LED, PinNonPhysical
+
+    PinNonPhysical.printWarnings = False
+    actled = LED(actpin)
+
 
 Errors
 ======
@@ -43,13 +54,19 @@ Errors
 
 .. autoexception:: BadEventHandler
 
+.. autoexception:: BadWaitTime
+
 .. autoexception:: BadQueueLen
 
-.. autoexception:: BadWaitTime
+.. autoexception:: BadPinFactory
 
 .. autoexception:: CompositeDeviceError
 
 .. autoexception:: CompositeDeviceBadName
+
+.. autoexception:: CompositeDeviceBadOrder
+
+.. autoexception:: CompositeDeviceBadDevice
 
 .. autoexception:: EnergenieSocketMissing
 
@@ -58,6 +75,8 @@ Errors
 .. autoexception:: SPIError
 
 .. autoexception:: SPIBadArgs
+
+.. autoexception:: SPIBadChannel
 
 .. autoexception:: GPIODeviceError
 
@@ -83,6 +102,8 @@ Errors
 
 .. autoexception:: PinInvalidEdges
 
+.. autoexception:: PinInvalidBounce
+
 .. autoexception:: PinSetInput
 
 .. autoexception:: PinFixedPull
@@ -95,11 +116,12 @@ Errors
 
 .. autoexception:: PinPWMFixedValue
 
+.. autoexception:: PinUnknownPi
+
 .. autoexception:: PinMultiplePins
 
 .. autoexception:: PinNoPins
 
-.. autoexception:: PinUnknownPi
 
 Warnings
 ========
@@ -110,3 +132,6 @@ Warnings
 
 .. autoexception:: SPISoftwareFallback
 
+.. autoexception:: PinWarning
+
+.. autoexception:: PinNonPhysical

--- a/gpiozero/pins/native.py
+++ b/gpiozero/pins/native.py
@@ -219,9 +219,10 @@ class NativePin(LocalPin):
             try:
                 cls.PI_INFO.physical_pin('GPIO%d' % number)
             except PinNoPins:
-                warnings.warn(
-                    PinNonPhysical(
-                        'no physical pins exist for GPIO%d' % number))
+                if PinNonPhysical.printWarnings:
+                    warnings.warn(
+                        PinNonPhysical(
+                            'no physical pins exist for GPIO%d' % number))
             self._number = number
             self._func_offset = self._MEM.GPFSEL_OFFSET + (number // 10)
             self._func_shift = (number % 10) * 3

--- a/gpiozero/pins/pigpiod.py
+++ b/gpiozero/pins/pigpiod.py
@@ -111,9 +111,10 @@ class PiGPIOPin(Pin):
             try:
                 self._pi_info.physical_pin('GPIO%d' % number)
             except PinNoPins:
-                warnings.warn(
-                    PinNonPhysical(
-                        'no physical pins exist for GPIO%d' % number))
+                if PinNonPhysical.printWarnings:
+                    warnings.warn(
+                        PinNonPhysical(
+                            'no physical pins exist for GPIO%d' % number))
             self._host = host
             self._port = port
             self._number = number

--- a/gpiozero/pins/rpigpio.py
+++ b/gpiozero/pins/rpigpio.py
@@ -12,6 +12,7 @@ from RPi import GPIO
 from . import LocalPin
 from .data import pi_info
 from ..exc import (
+    GPIOZeroWarning,
     PinInvalidFunction,
     PinSetInput,
     PinFixedPull,
@@ -90,9 +91,10 @@ class RPiGPIOPin(LocalPin):
             try:
                 cls.PI_INFO.physical_pin('GPIO%d' % number)
             except PinNoPins:
-                warnings.warn(
-                    PinNonPhysical(
-                        'no physical pins exist for GPIO%d' % number))
+                if PinNonPhysical.printWarnings:
+                    warnings.warn(
+                        PinNonPhysical(
+                            'no physical pins exist for GPIO%d' % number))
             self._number = number
             self._pull = 'up' if cls.PI_INFO.pulled_up('GPIO%d' % number) else 'floating'
             self._pwm = None

--- a/gpiozero/pins/rpio.py
+++ b/gpiozero/pins/rpio.py
@@ -87,9 +87,10 @@ class RPIOPin(LocalPin):
             try:
                 cls.PI_INFO.physical_pin('GPIO%d' % number)
             except PinNoPins:
-                warnings.warn(
-                    PinNonPhysical(
-                        'no physical pins exist for GPIO%d' % number))
+                if PinNonPhysical.printWarnings:
+                    warnings.warn(
+                        PinNonPhysical(
+                            'no physical pins exist for GPIO%d' % number))
             self._number = number
             self._pull = 'up' if cls.PI_INFO.pulled_up('GPIO%d' % number) else 'floating'
             self._pwm = False

--- a/gpiozero/spi.py
+++ b/gpiozero/spi.py
@@ -394,9 +394,10 @@ def SPI(**spi_args):
             spi_args['select_pin'] in (7, 8),
             )):
         if SpiDev is None:
-            warnings.warn(
-                SPISoftwareFallback(
-                    'failed to import spidev, falling back to software SPI'))
+            if SPISoftwareFallback.printWarnings:
+                warnings.warn(
+                    SPISoftwareFallback(
+                        'failed to import spidev, falling back to software SPI'))
         else:
             try:
                 hardware_spi_args = {
@@ -408,10 +409,11 @@ def SPI(**spi_args):
                 else:
                     return SPIHardwareInterface(**hardware_spi_args)
             except Exception as e:
-                warnings.warn(
-                    SPISoftwareFallback(
-                        'failed to initialize hardware SPI, falling back to '
-                        'software (error was: %s)' % str(e)))
+                if SPISoftwareFallback.printWarnings:
+                    warnings.warn(
+                        SPISoftwareFallback(
+                            'failed to initialize hardware SPI, falling back to '
+                            'software (error was: %s)' % str(e)))
     if shared:
         return SharedSPISoftwareInterface(**spi_args)
     else:


### PR DESCRIPTION
Add `GPIOZeroWarnings.printWarnings` class variable.
Use subclass versions of it before calling `warnings.warn()`.
Add missing exceptions/warnings to docs/api_exc.rst, and document new class variable and show an example of its use.

Fixes issue #511.
