### PR TITLE
Moved pull_up from super to init, close #505

### DIFF
--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -394,12 +394,18 @@ class MotionSensor(SmoothedInputDevice):
         :attr:`~SmoothedInputDevice.is_active` until the internal queue has
         filled with values.  Only set this to ``True`` if you require values
         immediately after object construction.
+
+    :param bool pull_up:
+        If ``False`` (the default), the GPIO pin will be pulled low by default.
+        In this case, connect the other side of the button to 3V3. If
+        ``True``, the GPIO pin will be pulled high by default. In this case,
+        connect the other side of the button to ground.
     """
     def __init__(
             self, pin=None, queue_len=1, sample_rate=10, threshold=0.5,
-            partial=False):
+            partial=False, pull_up=False):
         super(MotionSensor, self).__init__(
-            pin, pull_up=False, threshold=threshold,
+            pin, pull_up, threshold=threshold,
             queue_len=queue_len, sample_wait=1 / sample_rate, partial=partial
         )
         try:

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -397,15 +397,15 @@ class MotionSensor(SmoothedInputDevice):
 
     :param bool pull_up:
         If ``False`` (the default), the GPIO pin will be pulled low by default.
-        In this case, connect the other side of the button to 3V3. If
+        In this case, connect the other side of the sensor to 3V3. If
         ``True``, the GPIO pin will be pulled high by default. In this case,
-        connect the other side of the button to ground.
+        connect the other side of the sensor to ground.
     """
     def __init__(
             self, pin=None, queue_len=1, sample_rate=10, threshold=0.5,
             partial=False, pull_up=False):
         super(MotionSensor, self).__init__(
-            pin, pull_up, threshold=threshold,
+            pin, pull_up=pull_up, threshold=threshold,
             queue_len=queue_len, sample_wait=1 / sample_rate, partial=partial
         )
         try:


### PR DESCRIPTION
Some PIR sensors are not pull_down by default but pull_up.
At `input_devices.py` the `pull_up=False` is hardcoded at `super`.
Moved up to `__init__` so for that case a user could do:

```python
from gpiozero import MotionSensor

pir = MotionSensor(4, pull_up=True)
while True:
    if pir.motion_detected:
        print("Motion detected!")
```

( @lurch edited this comment to add extra code-formatting )