### PR TITLE
Added required dependencies in setup.py (RPi.GPIO, spidev)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ __keywords__ = [
 ]
 
 __requires__ = [
+    'RPi.GPIO',
+    'spidev'
 ]
 
 __extra_requires__ = {


### PR DESCRIPTION
gpiozero relies on these libraries in order to correctly identify
the pin setup on the Raspberry Pi, and the absence of these libraries
results in weird issues relating to the incorrect identification of
PWM support on unsupported pins.