### PR TITLE
Add --xyz option to pinout cli tool

### DIFF
--- a/docs/cli_pinout.rst
+++ b/docs/cli_pinout.rst
@@ -43,7 +43,7 @@ Options
 
 .. option:: -x, --xyz
 
-    Open pinout.xyz in the default web browser
+    Open `pinout.xyz`_ in the default web browser
 
 Examples
 --------
@@ -176,4 +176,5 @@ PIGPIO_PORT
 
         :manpage:`remote-gpio(7)`
 
+.. _pinout.xyz: https://pinout.xyz/
 .. _revision codes: https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md

--- a/docs/cli_pinout.rst
+++ b/docs/cli_pinout.rst
@@ -8,7 +8,7 @@ Synopsis
 
 ::
 
-    pinout [-h] [-r REVISION] [-c] [-m]
+    pinout [-h] [-r REVISION] [-c] [-m] [-x]
 
 Description
 -----------
@@ -40,6 +40,10 @@ Options
 .. option:: -m, --monochrome
 
     Force monochrome output. See also :option:`--color`
+
+.. option:: -x, --xyz
+
+    Open pinout.xyz in the default web browser
 
 Examples
 --------
@@ -172,4 +176,4 @@ PIGPIO_PORT
 
         :manpage:`remote-gpio(7)`
 
-.. _revision codes: http://elinux.org/RPi_HardwareHistory
+.. _revision codes: https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md

--- a/gpiozerocli/pinout.py
+++ b/gpiozerocli/pinout.py
@@ -13,6 +13,7 @@ import argparse
 import sys
 import textwrap
 import warnings
+import webbrowser
 
 class PinoutTool(object):
     def __init__(self):
@@ -37,6 +38,12 @@ class PinoutTool(object):
             dest='color',
             action='store_false',
             help='Force monochrome output. See also --color'
+        )
+        self.parser.add_argument(
+            '-x', '--xyz',
+            dest='xyz',
+            action='store_true',
+            help='Open pinout.xyz in the default web browser'
         )
 
     def __call__(self, args=None):
@@ -73,7 +80,9 @@ class PinoutTool(object):
             )
             sys.stderr.write(formatter.format_help())
         else:
-            if args.revision == '':
+            if args.xyz:
+                webbrowser.open('https://pinout.xyz')
+            elif args.revision == '':
                 try:
                     pi_info().pprint(color=args.color)
                 except IOError:

--- a/gpiozerocli/pinout.py
+++ b/gpiozerocli/pinout.py
@@ -82,19 +82,21 @@ class PinoutTool(object):
         else:
             if args.xyz:
                 webbrowser.open('https://pinout.xyz')
-            elif args.revision == '':
-                try:
-                    pi_info().pprint(color=args.color)
-                except IOError:
-                    raise IOError('This device is not a Raspberry Pi')
             else:
-                pi_info(args.revision).pprint(color=args.color)
-            formatter = self.parser._get_formatter()
-            formatter.add_text(
-                "For further information, please refer to https://pinout.xyz/"
-            )
-            sys.stdout.write('\n')
-            sys.stdout.write(formatter.format_help())
+                if args.revision == '':
+                    try:
+                        pi_info().pprint(color=args.color)
+                    except IOError:
+                        raise IOError('This device is not a Raspberry Pi')
+                else:
+                    pi_info(args.revision).pprint(color=args.color)
+                formatter = self.parser._get_formatter()
+                formatter.add_text(
+                    "For further information, please refer to "
+                    "https://pinout.xyz/"
+                )
+                sys.stdout.write('\n')
+                sys.stdout.write(formatter.format_help())
 
 
 main = PinoutTool()

--- a/gpiozerocli/pinout.py
+++ b/gpiozerocli/pinout.py
@@ -76,7 +76,7 @@ class PinoutTool(object):
                 "remotely access your Pi."
             )
             formatter.add_text(
-                "* https://gpiozero.readthedocs.io/en/latest/remote_gpio.html"
+                "* https://gpiozero.readthedocs.io/en/stable/remote_gpio.html"
             )
             sys.stderr.write(formatter.format_help())
         else:


### PR DESCRIPTION
I suggested at one point that we add an option to `pinout` to open [pinout.xyz](https://pinout.xyz) in a browser but we decided against it due to cross-platform issues.

However, it occured to me that `import antigravity` is in the standard library and I assume it works cross-platform.

I looked at the [source](https://github.com/python/cpython/blob/master/Lib/antigravity.py) for `import antigravity` and it uses the built-in `webbrowser` module ([source](https://github.com/python/cpython/blob/master/Lib/webbrowser.py)).

I haven't tested it on another machine yet.

Usage:

```
$ pinout -x
$ pinout --xyz
```

WIP: needs docs updating if approved in principle.