### PR TITLE
Fix SmoothedInputDevice to use the mean of the values, matching the docs

### DIFF
--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -9,6 +9,10 @@ from __future__ import (
 
 from time import sleep, time
 from threading import Event
+try:
+    from statistics import mean
+except ImportError:
+    from .compat import mean
 
 from .exc import InputDeviceError, DeviceClosed
 from .devices import GPIODevice
@@ -151,7 +155,7 @@ class SmoothedInputDevice(EventsMixin, InputDevice):
             pin, pull_up, pin_factory=pin_factory
         )
         try:
-            self._queue = GPIOQueue(self, queue_len, sample_wait, partial)
+            self._queue = GPIOQueue(self, queue_len, sample_wait, partial, mean)
             self.threshold = float(threshold)
         except:
             self.close()


### PR DESCRIPTION
Fixes #615 

I'm afraid I couldn't think of any way of unit-testing this.