### PR TITLE
Fix creation of virtualenv using mkvirtualenv

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -33,9 +33,13 @@ within a virtual Python environment:
 .. code-block:: console
 
     $ sudo apt install lsb-release build-essential git git-core \
-    >   exuberant-ctags virtualenvwrapper python-virtualenv python3-virtualenv \
-    >   python-dev python3-dev
+        exuberant-ctags virtualenvwrapper python-virtualenv python3-virtualenv \
+        python-dev python3-dev
     $ cd
+    $ mkdir .virtualenvs
+    $ echo -e "\nexport WORKON_HOME=$HOME/.virtualenvs" >> .bashrc
+    $ echo "source /usr/share/virtualenvwrapper/virtualenvwrapper.sh" >> .bashrc
+    $ source .bashrc
     $ mkvirtualenv -p /usr/bin/python3 python-gpiozero
     $ workon python-gpiozero
     (python-gpiozero) $ git clone https://github.com/RPi-Distro/python-gpiozero.git


### PR DESCRIPTION
See issue reported in #630 
I have tested that you can move around virtualenvs with ```workon <virtualenv>``` and that you can ```make develop``` and ```make doc``` without any errors.
It was almost fixed in #632 but I hadn't created and linked to the .virtualenv directory which broke ```make doc```.  @waveform80 could you please check this PR as @bennuttall is concerned about adding the lines to .bashrc (see https://github.com/RPi-Distro/python-gpiozero/pull/632#issuecomment-376183461).
