### PR TITLE
Add support for colorzero with RGBLED

### DIFF
--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -8,6 +8,7 @@ from __future__ import (
 from threading import Lock
 from itertools import repeat, cycle, chain
 from collections import OrderedDict
+from colorzero import Color, Red, Green, Blue
 
 from .exc import OutputDeviceBadValue, GPIOPinMissing
 from .devices import GPIODevice, Device, CompositeDevice
@@ -540,15 +541,6 @@ class PWMLED(PWMOutputDevice):
 PWMLED.is_lit = PWMLED.is_active
 
 
-def _led_property(index, doc=None):
-    def getter(self):
-        return self._leds[index].value
-    def setter(self, value):
-        self._stop_blink()
-        self._leds[index].value = value
-    return property(getter, setter, doc=doc)
-
-
 class RGBLED(SourceMixin, Device):
     """
     Extends :class:`Device` and represents a full color LED component (composed
@@ -606,10 +598,6 @@ class RGBLED(SourceMixin, Device):
         )
         self.value = initial_value
 
-    red = _led_property(0)
-    green = _led_property(1)
-    blue = _led_property(2)
-
     def close(self):
         if getattr(self, '_leds', None):
             self._stop_blink()
@@ -654,7 +642,56 @@ class RGBLED(SourceMixin, Device):
         return self.value != (0, 0, 0)
 
     is_lit = is_active
-    color = value
+
+    @property
+    def color(self):
+        """
+        Represents the color of the LED as a :class:`~colorzero.`Color` object.
+        """
+        return Color(*self.value)
+
+    @color.setter
+    def color(self, value):
+        if isinstance(value, Color):
+            self.value = value.rgb
+        else:
+            self.value = value
+
+    @property
+    def red(self):
+        return Red(self.value[0])
+
+    @red.setter
+    def red(self, value):
+        self._stop_blink()
+        if isinstance(value, Red):
+            self.value = float(value)
+        else:
+            self._leds[0].value = value
+
+    @property
+    def green(self):
+        return Green(self.value[0])
+
+    @green.setter
+    def green(self, value):
+        self._stop_blink()
+        if isinstance(value, Green):
+            self.value = float(value)
+        else:
+            self._leds[0].value = value
+
+    @property
+    def blue(self):
+        return Blue(self.value[0])
+
+    @blue.setter
+    def blue(self, value):
+        self._stop_blink()
+        if isinstance(value, Blue):
+            self.value = float(value)
+        else:
+            self._leds[0].value = value
 
     def on(self):
         """

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -618,10 +618,10 @@ class RGBLED(SourceMixin, Device):
         blue)`` where each value is between 0 and 1 if ``pwm`` was ``True``
         when the class was constructed (and only 0 or 1 if not).
 
-        For example, purple would be ``(1, 0, 1)`` and yellow would be ``(1, 1,
+        For example, red would be ``(1, 0, 0)`` and yellow would be ``(1, 1,
         0)``, while orange would be ``(1, 0.5, 0)``.
         """
-        return (self.red, self.green, self.blue)
+        return tuple(led.value for led in self._leds)
 
     @value.setter
     def value(self, value):
@@ -632,7 +632,8 @@ class RGBLED(SourceMixin, Device):
                 if component not in (0, 1):
                     raise OutputDeviceBadValue('each RGB color component must be 0 or 1 with non-PWM RGBLEDs')
         self._stop_blink()
-        self.red, self.green, self.blue = value
+        for led, v in zip(self._leds, value):
+            led.value = v
 
     @property
     def is_active(self):
@@ -660,39 +661,45 @@ class RGBLED(SourceMixin, Device):
 
     @property
     def red(self):
-        return Red(self._leds[0].value)
+        """
+        Represents the red element of the LED as a :class:`~colorzero.Red`
+        object.
+        """
+        return self.color.red
 
     @red.setter
     def red(self, value):
         self._stop_blink()
-        if isinstance(value, Red):
-            self.value = float(value)
-        else:
-            self._leds[0].value = value
+        r, g, b = self.value
+        self.value = value, g, b
 
     @property
     def green(self):
-        return Green(self._leds[1].value)
+        """
+        Represents the green element of the LED as a :class:`~colorzero.Green`
+        object.
+        """
+        return self.color.green
 
     @green.setter
     def green(self, value):
         self._stop_blink()
-        if isinstance(value, Green):
-            self.value = float(value)
-        else:
-            self._leds[1].value = value
+        r, g, b = self.value
+        self.value = r, value, b
 
     @property
     def blue(self):
-        return Blue(self._leds[2].value)
+        """
+        Represents the blue element of the LED as a :class:`~colorzero.Blue`
+        object.
+        """
+        return self.color.blue
 
     @blue.setter
     def blue(self, value):
         self._stop_blink()
-        if isinstance(value, Blue):
-            self.value = float(value)
-        else:
-            self._leds[2].value = value
+        r, g, b = self.value
+        self.value = r, g, value
 
     def on(self):
         """

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -654,10 +654,7 @@ class RGBLED(SourceMixin, Device):
 
     @color.setter
     def color(self, value):
-        if isinstance(value, Color):
-            self.value = value.rgb
-        else:
-            self.value = value
+        self.value = value
 
     @property
     def red(self):

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -659,7 +659,7 @@ class RGBLED(SourceMixin, Device):
 
     @property
     def red(self):
-        return Red(self.value[0])
+        return Red(self._leds[0].value)
 
     @red.setter
     def red(self, value):
@@ -671,7 +671,7 @@ class RGBLED(SourceMixin, Device):
 
     @property
     def green(self):
-        return Green(self.value[0])
+        return Green(self._leds[1].value)
 
     @green.setter
     def green(self, value):
@@ -679,11 +679,11 @@ class RGBLED(SourceMixin, Device):
         if isinstance(value, Green):
             self.value = float(value)
         else:
-            self._leds[0].value = value
+            self._leds[1].value = value
 
     @property
     def blue(self):
-        return Blue(self.value[0])
+        return Blue(self._leds[2].value)
 
     @blue.setter
     def blue(self, value):
@@ -691,7 +691,7 @@ class RGBLED(SourceMixin, Device):
         if isinstance(value, Blue):
             self.value = float(value)
         else:
-            self._leds[0].value = value
+            self._leds[2].value = value
 
     def on(self):
         """

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -646,7 +646,7 @@ class RGBLED(SourceMixin, Device):
     @property
     def color(self):
         """
-        Represents the color of the LED as a :class:`~colorzero.`Color` object.
+        Represents the color of the LED as a :class:`~colorzero.Color` object.
         """
         return Color(*self.value)
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ __keywords__ = [
 ]
 
 __requires__ = [
+    'colorzero',
 ]
 
 __extra_requires__ = {

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -15,6 +15,7 @@ except ImportError:
     from gpiozero.compat import isclose
 
 import pytest
+from colorzero import Color, Red, Green, Blue
 
 from gpiozero.pins.mock import MockPin, MockPWMPin
 from gpiozero import *
@@ -43,8 +44,11 @@ def setup_function(function):
         'test_rgbled_value',
         'test_rgbled_bad_value',
         'test_rgbled_toggle',
-        'test_rgbled_bad_color_pwm',
-        'test_rgbled_color_pwm',
+        'test_rgbled_bad_color_value_pwm',
+        'test_rgbled_color_value_pwm',
+        'test_rgbled_bad_rgb_property_pwm',
+        'test_rgbled_rgb_property_pwm',
+        'test_rgbled_color_name_pwm',
         'test_rgbled_blink_background',
         'test_rgbled_blink_foreground',
         'test_rgbled_fade_background',
@@ -554,7 +558,7 @@ def test_rgbled_toggle_nonpwm():
         assert not led.is_active
         assert led.value == (0, 0, 0)
 
-def test_rgbled_bad_color_nopwm():
+def test_rgbled_bad_color_value_nopwm():
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.color = (0.5, 0, 0)
@@ -562,14 +566,19 @@ def test_rgbled_bad_color_nopwm():
             led.color = (0, 1.5, 0)
         with pytest.raises(ValueError):
             led.color = (0, 0, -1)
+
+def test_rgbled_bad_color_value_pwm():
+    with RGBLED(1, 2, 3) as led:
         with pytest.raises(ValueError):
-            led.red = 0.5
+            led.color = (0, 1.5, 0)
+        with pytest.raises(ValueError):
+            led.color = (0, 0, -1)
         with pytest.raises(ValueError):
             led.green = 1.5
         with pytest.raises(ValueError):
             led.blue = -1
 
-def test_rgbled_color_nopwm():
+def test_rgbled_color_value_nopwm():
     with RGBLED(1, 2, 3, pwm=False) as led:
         assert led.value == (0, 0, 0)
         assert led.red == 0
@@ -593,18 +602,7 @@ def test_rgbled_color_nopwm():
         led.blue = 1
         assert led.value == (1, 0, 1)
 
-def test_rgbled_bad_color_pwm():
-    with RGBLED(1, 2, 3) as led:
-        with pytest.raises(ValueError):
-            led.color = (0, 1.5, 0)
-        with pytest.raises(ValueError):
-            led.color = (0, 0, -1)
-        with pytest.raises(ValueError):
-            led.green = 1.5
-        with pytest.raises(ValueError):
-            led.blue = -1
-
-def test_rgbled_color_pwm():
+def test_rgbled_color_value_pwm():
     with RGBLED(1, 2, 3) as led:
         assert led.value == (0, 0, 0)
         assert led.red == 0
@@ -627,6 +625,101 @@ def test_rgbled_color_pwm():
         led.green = 0.9
         led.blue = 0.4
         assert led.value == (0.5, 0.9, 0.4)
+
+def test_rgbled_bad_rgb_property_nopwm():
+    with RGBLED(1, 2, 3, pwm=False) as led:
+        with pytest.raises(ValueError):
+            led.red = 0.1
+        with pytest.raises(ValueError):
+            led.green = 0.5
+        with pytest.raises(ValueError):
+            led.blue = 0.9
+        with pytest.raises(ValueError):
+            led.red = Red(0.1)
+        with pytest.raises(ValueError):
+            led.green = Green(0.5)
+        with pytest.raises(ValueError):
+            led.blue = Blue(0.9)
+
+def test_rgbled_bad_rgb_property_pwm():
+    with RGBLED(1, 2, 3) as led:
+        with pytest.raises(ValueError):
+            led.red = 1.5
+        with pytest.raises(ValueError):
+            led.green = 2
+        with pytest.raises(ValueError):
+            led.blue = -1
+        with pytest.raises(ValueError):
+            led.red = Red(1.5)
+        with pytest.raises(ValueError):
+            led.green = Green(2)
+        with pytest.raises(ValueError):
+            led.blue = Blue(-1)
+
+def test_rgbled_rgb_property_nopwm():
+    with RGBLED(1, 2, 3, pwm=False) as led:
+        assert led.value == (0, 0, 0)
+        led.red = Red(0)
+        assert led.value == (0, 0, 0)
+        led.red = Red(1)
+        assert led.value == (1, 0, 0)
+        led.green = Green(1)
+        assert led.value == (1, 1, 0)
+        led.blue = Blue(1)
+        assert led.value == (1, 1, 1)
+
+def test_rgbled_rgb_property_pwm():
+    with RGBLED(1, 2, 3) as led:
+        assert led.value == (0, 0, 0)
+        led.red = Red(0)
+        assert led.value == (0, 0, 0)
+        led.red = Red(0.5)
+        assert led.value == (0.5, 0, 0)
+        led.green = Green(0.5)
+        assert led.value == (0.5, 0.5, 0)
+        led.blue = Blue(0.5)
+        assert led.value == (0.5, 0.5, 0.5)
+
+def test_rgbled_bad_color_name_nopwm():
+    with RGBLED(1, 2, 3, pwm=False) as led:
+        with pytest.raises(ValueError):
+            led.color = Color('green')  # html 'green' is (0, ~0.5, 0)
+        with pytest.raises(ValueError):
+            led.color = Color(0.5, 0, 0)
+        with pytest.raises(ValueError):
+            led.color = Color(250, 0, 0)
+
+def test_rgbled_color_name_nopwm():
+    with RGBLED(1, 2, 3, pwm=False) as led:
+        assert led.value == (0, 0, 0)
+        led.color = Color('white')
+        assert led.value == (1, 1, 1)
+        led.color = Color('black')
+        assert led.value == (0, 0, 0)
+        led.color = Color('red')
+        assert led.value == (1, 0, 0)
+        led.color = Color('lime')  # html 'green' is (0, 0.5, 0)
+        assert led.value == (0, 1, 0)
+        led.color = Color('blue')
+        assert led.value == (0, 0, 1)
+        led.color = Color('cyan')
+        assert led.value == (0, 1, 1)
+        led.color = Color('magenta')
+        assert led.value == (1, 0, 1)
+        led.color = Color('yellow')
+        assert led.value == (1, 1, 0)
+
+def test_rgbled_color_name_pwm():
+    with RGBLED(1, 2, 3) as led:
+        assert led.value == (0, 0, 0)
+        led.color = Color('white')
+        assert led.value == (1, 1, 1)
+        led.color = Color('green')
+        assert led.value == (0, 0.5019607843137255, 0)
+        led.color = Color('chocolate')
+        assert led.value == (0.8235294117647058, 0.4117647058823529, 0.11764705882352941)
+        led.color = Color('purple')
+        assert led.value == (0.5019607843137255, 0.0, 0.5019607843137255)
 
 def test_rgbled_blink_nonpwm():
     with RGBLED(1, 2, 3, pwm=False) as led:

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -43,6 +43,8 @@ def setup_function(function):
         'test_rgbled_value',
         'test_rgbled_bad_value',
         'test_rgbled_toggle',
+        'test_rgbled_bad_color_pwm',
+        'test_rgbled_color_pwm',
         'test_rgbled_blink_background',
         'test_rgbled_blink_foreground',
         'test_rgbled_fade_background',
@@ -467,17 +469,14 @@ def test_rgbled_initial_value_nonpwm():
         assert b.state == 1
 
 def test_rgbled_initial_bad_value():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
     with pytest.raises(ValueError):
         RGBLED(1, 2, 3, initial_value=(0.1, 0.2, 1.2))
 
 def test_rgbled_initial_bad_value_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
     with pytest.raises(ValueError):
         RGBLED(1, 2, 3, pwm=False, initial_value=(0.1, 0.2, 0))
 
 def test_rgbled_value():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3) as led:
         assert isinstance(led._leds[0], PWMLED)
         assert isinstance(led._leds[1], PWMLED)
@@ -495,7 +494,6 @@ def test_rgbled_value():
         assert led.value == (0.5, 0.5, 0.5)
 
 def test_rgbled_value_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3, pwm=False) as led:
         assert isinstance(led._leds[0], LED)
         assert isinstance(led._leds[1], LED)
@@ -510,7 +508,6 @@ def test_rgbled_value_nonpwm():
         assert led.value == (0, 0, 0)
 
 def test_rgbled_bad_value():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3) as led:
         with pytest.raises(ValueError):
             led.value = (2, 0, 0)
@@ -519,7 +516,6 @@ def test_rgbled_bad_value():
             led.value = (0, -1, 0)
 
 def test_rgbled_bad_value_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.value = (2, 0, 0)
@@ -537,7 +533,6 @@ def test_rgbled_bad_value_nonpwm():
             led.value = (0, 0, 0.5)
 
 def test_rgbled_toggle():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3) as led:
         assert not led.is_active
         assert led.value == (0, 0, 0)
@@ -549,7 +544,6 @@ def test_rgbled_toggle():
         assert led.value == (0, 0, 0)
 
 def test_rgbled_toggle_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3, pwm=False) as led:
         assert not led.is_active
         assert led.value == (0, 0, 0)
@@ -560,8 +554,81 @@ def test_rgbled_toggle_nonpwm():
         assert not led.is_active
         assert led.value == (0, 0, 0)
 
+def test_rgbled_bad_color_nopwm():
+    with RGBLED(1, 2, 3, pwm=False) as led:
+        with pytest.raises(ValueError):
+            led.color = (0.5, 0, 0)
+        with pytest.raises(ValueError):
+            led.color = (0, 1.5, 0)
+        with pytest.raises(ValueError):
+            led.color = (0, 0, -1)
+        with pytest.raises(ValueError):
+            led.red = 0.5
+        with pytest.raises(ValueError):
+            led.green = 1.5
+        with pytest.raises(ValueError):
+            led.blue = -1
+
+def test_rgbled_color_nopwm():
+    with RGBLED(1, 2, 3, pwm=False) as led:
+        assert led.value == (0, 0, 0)
+        assert led.red == 0
+        assert led.green == 0
+        assert led.blue == 0
+        led.on()
+        assert led.value == (1, 1, 1)
+        assert led.color == (1, 1, 1)
+        assert led.red == 1
+        assert led.green == 1
+        assert led.blue == 1
+        led.color = (0, 1, 0)
+        assert led.value == (0, 1, 0)
+        assert led.red == 0
+        led.red = 1
+        assert led.value == (1, 1, 0)
+        assert led.red == 1
+        assert led.green == 1
+        assert led.blue == 0
+        led.green = 0
+        led.blue = 1
+        assert led.value == (1, 0, 1)
+
+def test_rgbled_bad_color_pwm():
+    with RGBLED(1, 2, 3) as led:
+        with pytest.raises(ValueError):
+            led.color = (0, 1.5, 0)
+        with pytest.raises(ValueError):
+            led.color = (0, 0, -1)
+        with pytest.raises(ValueError):
+            led.green = 1.5
+        with pytest.raises(ValueError):
+            led.blue = -1
+
+def test_rgbled_color_pwm():
+    with RGBLED(1, 2, 3) as led:
+        assert led.value == (0, 0, 0)
+        assert led.red == 0
+        assert led.green == 0
+        assert led.blue == 0
+        led.on()
+        assert led.value == (1, 1, 1)
+        assert led.color == (1, 1, 1)
+        assert led.red == 1
+        assert led.green == 1
+        assert led.blue == 1
+        led.color = (0.2, 0.5, 0.8)
+        assert led.value == (0.2, 0.5, 0.8)
+        assert led.red == 0.2
+        led.red = 0.5
+        assert led.value == (0.5, 0.5, 0.8)
+        assert led.red == 0.5
+        assert led.green == 0.5
+        assert led.blue == 0.8
+        led.green = 0.9
+        led.blue = 0.4
+        assert led.value == (0.5, 0.9, 0.4)
+
 def test_rgbled_blink_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.blink(fade_in_time=1)


### PR DESCRIPTION
I wondered if we could support using `colorzero.Color` for RGBLEDBoard's `color` property, and similarly `Red`, `Green` and `Blue` while allowing those properties to be set the current way (with integers / integer tuples).