### PR TITLE
Fix passing tuple to spidev's xfer2 method (requires lists)

### DIFF
--- a/gpiozero/pins/__init__.py
+++ b/gpiozero/pins/__init__.py
@@ -429,7 +429,7 @@ class SPI(object):
         half-duplex communication. See :meth:`transfer` for full duplex
         communication.
         """
-        return self.transfer((0,) * n)
+        return self.transfer([0] * n)
 
     def write(self, data):
         """


### PR DESCRIPTION
With `spidev==3.2` and `Python 3.6.6`, using native GPIO and hardware SPI, following error happens:
```
Traceback (most recent call last):
  File "./adc-spi-read.py", line 12, in <module>
    voltage = 3.3 * adc.value
  File "/home/spi/.local/lib/python3.6/site-packages/gpiozero/spi_devices.py", line 146, in value
    return (2 * (self._read() - self._min_value) / self._range) - 1
  File "/home/spi/.local/lib/python3.6/site-packages/gpiozero/spi_devices.py", line 450, in _read
    return self._words_to_int(self._spi.read(2), 13) >> 1
  File "/home/spi/.local/lib/python3.6/site-packages/gpiozero/pins/__init__.py", line 432, in read
    return self.transfer((0,) * n)
  File "/home/spi/.local/lib/python3.6/site-packages/gpiozero/pins/local.py", line 122, in transfer
    return self._interface.xfer2(data)
TypeError: xfer2() argument 1 must be list, not tuple
```

adc-spi-read.py script that triggers above error:
```
#!/usr/bin/env python3

import os, sys, warnings
if not sys.warnoptions: warnings.simplefilter('error') # prevent any fallbacks
os.environ['GPIOZERO_PIN_FACTORY'] = 'native'

from gpiozero import MCP3201
adc = MCP3201(clock_pin=11, mosi_pin=10, miso_pin=9, select_pin=8)
voltage = 3.3 * adc.value
print('voltage:', voltage)
```

Only place where `SPI.transfer()` happens with tuple afaict is the line affected by this patch.
Applying it fixes the issue, and code above works as expected, communicating with IC over SPI and printing result without errors.
