### PR TITLE
Pin event timing (fixes #664)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ develop: tags
 	$(PIP) install -e .[doc,test]
 
 test:
-	$(COVERAGE) run -m $(PYTEST) tests -v -r sx
+	$(COVERAGE) run --rcfile coverage.cfg -m $(PYTEST) tests -v -r sx
 	$(COVERAGE) report --rcfile coverage.cfg
 
 clean:

--- a/debian/rules
+++ b/debian/rules
@@ -17,10 +17,6 @@ override_dh_auto_install:
 override_dh_auto_test:
 	# Don't run the tests!
 
-#override_dh_installdocs:
-#	python setup.py build_sphinx -b html
-#	dh_installdocs
-
 override_dh_auto_build:
 	dh_auto_build
 	PYTHONPATH=. sphinx-build -N -bhtml docs/ build/html

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -158,16 +158,16 @@ class ButtonBoard(HoldMixin, CompositeDevice):
                 for name, pin in kwargs.items()
                 })
         def get_new_handler(device):
-            def fire_both_events(ticks):
-                device._fire_events(ticks)
-                self._fire_events(ticks)
+            def fire_both_events(ticks, state):
+                device._fire_events(ticks, device._state_to_value(state))
+                self._fire_events(ticks, self.value)
             return fire_both_events
         for button in self:
             button.pin.when_changed = get_new_handler(button)
         self._when_changed = None
         self._last_value = None
         # Call _fire_events once to set initial state of events
-        self._fire_events()
+        self._fire_events(self.pin_factory.ticks(), None)
         self.hold_time = hold_time
         self.hold_repeat = hold_repeat
 
@@ -191,10 +191,9 @@ class ButtonBoard(HoldMixin, CompositeDevice):
         if self.when_changed:
             self.when_changed()
 
-    def _fire_events(self, ticks):
-        super(ButtonBoard, self)._fire_events(ticks)
-        old_value = self._last_value
-        new_value = self._last_value = self.value
+    def _fire_events(self, ticks, new_value):
+        super(ButtonBoard, self)._fire_events(ticks, new_value)
+        old_value, self._last_value = self._last_value, new_value
         if old_value is None:
             # Initial "indeterminate" value; don't do anything
             pass

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -158,9 +158,9 @@ class ButtonBoard(HoldMixin, CompositeDevice):
                 for name, pin in kwargs.items()
                 })
         def get_new_handler(device):
-            def fire_both_events():
-                device._fire_events()
-                self._fire_events()
+            def fire_both_events(ticks):
+                device._fire_events(ticks)
+                self._fire_events(ticks)
             return fire_both_events
         for button in self:
             button.pin.when_changed = get_new_handler(button)
@@ -191,8 +191,8 @@ class ButtonBoard(HoldMixin, CompositeDevice):
         if self.when_changed:
             self.when_changed()
 
-    def _fire_events(self):
-        super(ButtonBoard, self)._fire_events()
+    def _fire_events(self, ticks):
+        super(ButtonBoard, self)._fire_events(ticks)
         old_value = self._last_value
         new_value = self._last_value = self.value
         if old_value is None:

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -669,7 +669,7 @@ class DistanceSensor(SmoothedInputDevice):
     ECHO_LOCK = Lock()
 
     def __init__(
-            self, echo=None, trigger=None, queue_len=10, max_distance=1,
+            self, echo=None, trigger=None, queue_len=9, max_distance=1,
             threshold_distance=0.3, partial=False, pin_factory=None):
         if max_distance <= 0:
             raise ValueError('invalid maximum distance (must be positive)')

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -107,7 +107,7 @@ class DigitalInputDevice(EventsMixin, InputDevice):
             self.pin.edges = 'both'
             self.pin.when_changed = self._pin_changed
             # Call _fire_events once to set initial state of events
-            self._fire_events(self.pin_factory.ticks(), None)
+            self._fire_events(self.pin_factory.ticks(), self.is_active)
         except:
             self.close()
             raise

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -107,7 +107,7 @@ class DigitalInputDevice(EventsMixin, InputDevice):
             self.pin.edges = 'both'
             self.pin.when_changed = self._fire_events
             # Call _fire_events once to set initial state of events
-            self._fire_events()
+            self._fire_events(self.pin_factory.ticks(), None)
         except:
             self.close()
             raise

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -105,12 +105,15 @@ class DigitalInputDevice(EventsMixin, InputDevice):
         try:
             self.pin.bounce = bounce_time
             self.pin.edges = 'both'
-            self.pin.when_changed = self._fire_events
+            self.pin.when_changed = self._pin_changed
             # Call _fire_events once to set initial state of events
             self._fire_events(self.pin_factory.ticks(), None)
         except:
             self.close()
             raise
+
+    def _pin_changed(self, ticks, state):
+        self._fire_events(ticks, self._state_to_value(state))
 
 
 class SmoothedInputDevice(EventsMixin, InputDevice):

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -53,7 +53,7 @@ class PingServer(InternalDevice):
     def __init__(self, host):
         self.host = host
         super(PingServer, self).__init__()
-        self._fire_events()
+        self._fire_events(self.pin_factory.ticks(), None)
 
     def __repr__(self):
         return '<gpiozero.PingServer host="%s">' % self.host
@@ -123,7 +123,7 @@ class CPUTemperature(InternalDevice):
         self.min_temp = min_temp
         self.max_temp = max_temp
         self.threshold = threshold
-        self._fire_events()
+        self._fire_events(self.pin_factory.ticks(), None)
 
     def __repr__(self):
         return '<gpiozero.CPUTemperature temperature=%.2f>' % self.temperature
@@ -154,6 +154,7 @@ class CPUTemperature(InternalDevice):
         :attr:`threshold`.
         """
         return self.temperature > self.threshold
+
 
 class LoadAverage(InternalDevice):
     """
@@ -209,7 +210,7 @@ class LoadAverage(InternalDevice):
             15: 2,
         }[minutes]
         super(LoadAverage, self).__init__()
-        self._fire_events()
+        self._fire_events(self.pin_factory.ticks(), None)
 
     def __repr__(self):
         return '<gpiozero.LoadAverage load average=%.2f>' % self.load_average
@@ -281,7 +282,7 @@ class TimeOfDay(InternalDevice):
         self.start_time = start_time
         self.end_time = end_time
         self.utc = utc
-        self._fire_events()
+        self._fire_events(self.pin_factory.ticks(), None)
 
     def __repr__(self):
         return '<gpiozero.TimeOfDay active between %s and %s %s>' % (

--- a/gpiozero/mixins.py
+++ b/gpiozero/mixins.py
@@ -12,7 +12,6 @@ import weakref
 from functools import wraps, partial
 from threading import Event
 from collections import deque
-from time import time
 try:
     from statistics import median
 except ImportError:
@@ -169,7 +168,7 @@ class EventsMixin(object):
         self._when_activated = None
         self._when_deactivated = None
         self._last_state = None
-        self._last_changed = time()
+        self._last_changed = self.pin_factory.ticks()
 
     def wait_for_active(self, timeout=None):
         """
@@ -240,7 +239,8 @@ class EventsMixin(object):
         When the device is inactive, this is ``None``.
         """
         if self._active_event.is_set():
-            return time() - self._last_changed
+            return self.pin_factory.ticks_diff(self.pin_factory.ticks(),
+                                               self._last_changed)
         else:
             return None
 
@@ -251,7 +251,8 @@ class EventsMixin(object):
         When the device is active, this is ``None``.
         """
         if self._inactive_event.is_set():
-            return time() - self._last_changed
+            return self.pin_factory.ticks_diff(self.pin_factory.ticks(),
+                                               self._last_changed)
         else:
             return None
 
@@ -307,7 +308,7 @@ class EventsMixin(object):
         if self.when_deactivated:
             self.when_deactivated()
 
-    def _fire_events(self):
+    def _fire_events(self, ticks):
         old_state = self._last_state
         new_state = self._last_state = self.is_active
         if old_state is None:
@@ -318,7 +319,7 @@ class EventsMixin(object):
             else:
                 self._inactive_event.set()
         elif old_state != new_state:
-            self._last_changed = time()
+            self._last_changed = self.pin_factory.ticks()
             if new_state:
                 self._inactive_event.clear()
                 self._active_event.set()
@@ -431,7 +432,8 @@ class HoldMixin(EventsMixin):
         this is ``None``.
         """
         if self._held_from is not None:
-            return time() - self._held_from
+            return self.pin_factory.ticks_diff(self.pin_factory.ticks(),
+                                               self._held_from)
         else:
             return None
 
@@ -458,7 +460,7 @@ class HoldThread(GPIOThread):
                             parent._inactive_event.wait(parent.hold_time)
                             ):
                         if parent._held_from is None:
-                            parent._held_from = time()
+                            parent._held_from = parent.pin_factory.ticks()
                         parent._fire_held()
                         if not parent.hold_repeat:
                             break
@@ -508,7 +510,7 @@ class GPIOQueue(GPIOThread):
                 if not self.full.is_set() and len(self.queue) >= self.queue.maxlen:
                     self.full.set()
                 if (self.partial or self.full.is_set()) and isinstance(self.parent, EventsMixin):
-                    self.parent._fire_events()
+                    self.parent._fire_events(self.parent.pin_factory.ticks())
         except ReferenceError:
             # Parent is dead; time to die!
             pass

--- a/gpiozero/mixins.py
+++ b/gpiozero/mixins.py
@@ -167,7 +167,7 @@ class EventsMixin(object):
         self._inactive_event = Event()
         self._when_activated = None
         self._when_deactivated = None
-        self._last_state = None
+        self._last_value = None
         self._last_changed = self.pin_factory.ticks()
 
     def wait_for_active(self, timeout=None):
@@ -308,21 +308,21 @@ class EventsMixin(object):
         if self.when_deactivated:
             self.when_deactivated()
 
-    def _fire_events(self, ticks, state):
-        old_state = self._last_state
-        # NOTE: we are interested in the state of the *device*, not the pin
-        # (hence why the state parameter is ignored here)
-        new_state = self._last_state = self.is_active
-        if old_state is None:
+    def _fire_events(self, ticks, new_value):
+        # NOTE: in contrast to the pin when_changed event, this method takes
+        # ticks and *value* (i.e. the device's .value) as opposed to a pin's
+        # *state*.
+        old_value, self._last_value = self._last_value, new_value
+        if old_value is None:
             # Initial "indeterminate" state; set events but don't fire
             # callbacks as there's not necessarily an edge
-            if new_state:
+            if new_value:
                 self._active_event.set()
             else:
                 self._inactive_event.set()
-        elif old_state != new_state:
+        elif old_value != new_value:
             self._last_changed = ticks
-            if new_state:
+            if new_value:
                 self._inactive_event.clear()
                 self._active_event.set()
                 self._fire_activated()

--- a/gpiozero/pins/__init__.py
+++ b/gpiozero/pins/__init__.py
@@ -416,9 +416,20 @@ class Pin(object):
         doc="""\
         A function or bound method to be called when the pin's state changes
         (more specifically when the edge specified by :attr:`edges` is detected
-        on the pin). The function or bound method must accept a single
-        parameter which will report the ticks (from :meth:`Factory.ticks`) when
-        the pin's state changed.
+        on the pin). The function or bound method must accept two parameters:
+        the first will report the ticks (from :meth:`Factory.ticks`) when
+        the pin's state changed, and the second will report the pin's current
+        state.
+
+        .. warning::
+
+            Depending on hardware support, the state is *not guaranteed to be
+            accurate*. For instance, many GPIO implementations will provide
+            an interrupt indicating when a pin's state changed but not what it
+            changed to. In this case the pin driver simply reads the pin's
+            current state to supply this parameter, but the pin's state may
+            have changed *since* the interrupt. Exercise appropriate caution
+            when relying upon this parameter.
 
         If the pin does not support edge detection, attempts to set this
         property will raise :exc:`PinEdgeDetectUnsupported`.

--- a/gpiozero/pins/__init__.py
+++ b/gpiozero/pins/__init__.py
@@ -31,8 +31,13 @@ from ..exc import (
 class Factory(object):
     """
     Generates pins and SPI interfaces for devices. This is an abstract
-    base class for pin factories. Descendents *may* override the following
-    methods, if applicable:
+    base class for pin factories. Descendents *must* override the following
+    methods:
+
+    * :meth:`ticks`
+    * :meth:`ticks_diff`
+
+    Descendents *may* override the following methods, if applicable:
 
     * :meth:`close`
     * :meth:`reserve_pins`
@@ -122,6 +127,28 @@ class Factory(object):
         raise :exc:`SPIBadArgs`.
         """
         raise PinSPIUnsupported('SPI not supported by this pin factory')
+
+    def ticks(self):
+        """
+        Return the current ticks, according to the factory. The reference point
+        is undefined and thus the result of this method is only meaningful when
+        compared to another value returned by this method.
+
+        The format of the time is also arbitrary, as is whether the time wraps
+        after a certain duration. Ticks should only be compared using the
+        :meth:`ticks_diff` method.
+        """
+        raise NotImplementedError
+
+    def ticks_diff(self, later, earlier):
+        """
+        Return the time in seconds between two :meth:`ticks` results. The
+        arguments are specified in the same order as they would be in the
+        formula *later* - *earlier* but the result is guaranteed to be in
+        seconds, and to be positive even if the ticks "wrapped" between calls
+        to :meth:`ticks`.
+        """
+        raise NotImplementedError
 
     def _get_pi_info(self):
         return None
@@ -389,7 +416,9 @@ class Pin(object):
         doc="""\
         A function or bound method to be called when the pin's state changes
         (more specifically when the edge specified by :attr:`edges` is detected
-        on the pin). The function or bound method must take no parameters.
+        on the pin). The function or bound method must accept a single
+        parameter which will report the ticks (from :meth:`Factory.ticks`) when
+        the pin's state changed.
 
         If the pin does not support edge detection, attempts to set this
         property will raise :exc:`PinEdgeDetectUnsupported`.
@@ -693,5 +722,3 @@ class SPI(object):
 
         Several implementations do not support non-byte-sized words.
         """)
-
-

--- a/gpiozero/pins/local.py
+++ b/gpiozero/pins/local.py
@@ -104,7 +104,7 @@ class LocalPiPin(PiPin):
             an opaque value that should only be compared with the associated
             :meth:`Factory.ticks_diff` method.
         """
-        super(LocalPiPin, self)._call_when_changed(self._factory.ticks())
+        super(LocalPiPin, self)._call_when_changed(self._factory.ticks(), self.state)
 
 
 class LocalPiHardwareSPI(SPI, Device):

--- a/gpiozero/pins/local.py
+++ b/gpiozero/pins/local.py
@@ -87,7 +87,7 @@ class LocalPiFactory(PiFactory):
         # and we fall back to time(). However, in that situation we've no
         # access to a true monotonic source, and no idea how far the clock has
         # skipped back so this is the best we can do anyway.
-        return later - earlier
+        return max(0, later - earlier)
 
 
 class LocalPiPin(PiPin):

--- a/gpiozero/pins/local.py
+++ b/gpiozero/pins/local.py
@@ -76,10 +76,12 @@ class LocalPiFactory(PiFactory):
                         return int(revision, base=16)
         raise PinUnknownPi('unable to locate Pi revision in /proc/cpuinfo or /proc/device-tree')
 
-    def ticks(self):
+    @staticmethod
+    def ticks():
         return monotonic()
 
-    def ticks_diff(self, later, earlier):
+    @staticmethod
+    def ticks_diff(later, earlier):
         # NOTE: technically the guarantee to always return a positive result
         # cannot be maintained in versions where monotonic() is not available
         # and we fall back to time(). However, in that situation we've no
@@ -93,9 +95,9 @@ class LocalPiPin(PiPin):
     Abstract base class representing a multi-function GPIO pin attached to the
     local Raspberry Pi.
     """
-    def _call_when_changed(self):
+    def _call_when_changed(self, ticks=None, state=None):
         """
-        Overridden to provide ticks from the local Pi factory.
+        Overridden to provide default ticks from the local Pi factory.
 
         .. warning::
 
@@ -104,7 +106,9 @@ class LocalPiPin(PiPin):
             an opaque value that should only be compared with the associated
             :meth:`Factory.ticks_diff` method.
         """
-        super(LocalPiPin, self)._call_when_changed(self._factory.ticks(), self.state)
+        super(LocalPiPin, self)._call_when_changed(
+            self._factory.ticks() if ticks is None else ticks,
+            self.state if state is None else state)
 
 
 class LocalPiHardwareSPI(SPI, Device):

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -26,13 +26,12 @@ from ..exc import (
     PinInvalidPull,
     )
 from ..devices import Device
-from .pi import PiPin
-from .local import LocalPiFactory
+from .local import LocalPiPin, LocalPiFactory
 
 
 PinState = namedtuple('PinState', ('timestamp', 'state'))
 
-class MockPin(PiPin):
+class MockPin(LocalPiPin):
     """
     A mock pin used primarily for testing. This class does *not* support PWM.
     """
@@ -118,23 +117,23 @@ class MockPin(PiPin):
         assert value in ('none', 'falling', 'rising', 'both')
         self._edges = value
 
-    def _get_when_changed(self):
-        return self._when_changed
+    def _disable_event_detect(self):
+        pass
 
-    def _set_when_changed(self, value):
-        self._when_changed = value
+    def _enable_event_detect(self):
+        pass
 
     def drive_high(self):
         assert self._function == 'input'
         if self._change_state(True):
             if self._edges in ('both', 'rising') and self._when_changed is not None:
-                self._when_changed()
+                self._call_when_changed()
 
     def drive_low(self):
         assert self._function == 'input'
         if self._change_state(False):
             if self._edges in ('both', 'falling') and self._when_changed is not None:
-                self._when_changed()
+                self._call_when_changed()
 
     def clear_states(self):
         self._last_change = time()
@@ -466,4 +465,3 @@ class MockFactory(LocalPiFactory):
             if issubclass(pin_class, MockPWMPin) != isinstance(pin, MockPWMPin):
                 raise ValueError('pin %d is already in use as a %s' % (n, pin.__class__.__name__))
         return pin
-

--- a/gpiozero/pins/native.py
+++ b/gpiozero/pins/native.py
@@ -12,10 +12,15 @@ import os
 import mmap
 import errno
 import struct
+import select
 import warnings
 from time import sleep
-from threading import Thread, Event, Lock
+from threading import Thread, Event, RLock
 from collections import Counter
+try:
+    from queue import Queue, Empty
+except ImportError:
+    from Queue import Queue, Empty
 
 from .local import LocalPiPin, LocalPiFactory
 from ..exc import (
@@ -31,11 +36,10 @@ class GPIOMemory(object):
 
     GPIO_BASE_OFFSET = 0x200000
     PERI_BASE_OFFSET = {
-        'BCM2708': 0x20000000,
         'BCM2835': 0x20000000,
-        'BCM2709': 0x3f000000,
         'BCM2836': 0x3f000000,
-        }
+        'BCM2837': 0x3f000000,
+    }
 
     # From BCM2835 data-sheet, p.91
     GPFSEL_OFFSET   = 0x00 >> 2
@@ -52,7 +56,7 @@ class GPIOMemory(object):
     GPPUD_OFFSET    = 0x94 >> 2
     GPPUDCLK_OFFSET = 0x98 >> 2
 
-    def __init__(self):
+    def __init__(self, rev):
         try:
             self.fd = os.open('/dev/gpiomem', os.O_RDWR | os.O_SYNC)
         except OSError:
@@ -63,7 +67,7 @@ class GPIOMemory(object):
                     'unable to open /dev/gpiomem or /dev/mem; '
                     'upgrade your kernel or run as root')
             else:
-                offset = self.peripheral_base() + self.GPIO_BASE_OFFSET
+                offset = self.peripheral_base(rev) + self.GPIO_BASE_OFFSET
         else:
             offset = 0
         self.mem = mmap.mmap(self.fd, 4096, offset=offset)
@@ -72,19 +76,17 @@ class GPIOMemory(object):
         self.mem.close()
         os.close(self.fd)
 
-    def peripheral_base(self):
+    def peripheral_base(self, rev):
         try:
             with io.open('/proc/device-tree/soc/ranges', 'rb') as f:
                 f.seek(4)
+                # This is deliberately a big-endian read
                 return struct.unpack(nstr('>L'), f.read(4))[0]
         except IOError:
-            with io.open('/proc/cpuinfo', 'r') as f:
-                for line in f:
-                    if line.startswith('Hardware'):
-                        try:
-                            return self.PERI_BASE_OFFSET[line.split(':')[1].strip()]
-                        except KeyError:
-                            raise IOError('unable to determine RPi revision')
+            try:
+                return self.PERI_BASE_OFFSET[rev]
+            except KeyError:
+                pass
         raise IOError('unable to determine peripheral base')
 
     def __getitem__(self, index):
@@ -98,52 +100,147 @@ class GPIOFS(object):
 
     GPIO_PATH = '/sys/class/gpio'
 
-    def __init__(self):
-        self._lock = Lock()
-        self._pin_refs = Counter()
+    def __init__(self, factory, queue):
+        self._lock = RLock()
+        self._exports = {}
+        self._thread = NativeWatchThread(factory, queue)
+
+    def close(self):
+        # We *could* track the stuff we've exported and unexport it here, but
+        # exports are a system global resource. We can't guarantee that some
+        # other process isn't relying on something we've exported. In other
+        # words, once exported it's *never* safe to unexport something. The
+        # unexport method below is largely provided for debugging and testing.
+        if self._thread is not None:
+            self._thread.close()
+            self._thread = None
 
     def path(self, name):
         return os.path.join(self.GPIO_PATH, name)
 
+    def path_value(self, pin):
+        return self.path('gpio%d/value' % pin)
+
+    def path_dir(self, pin):
+        return self.path('gpio%d/direction' % pin)
+
+    def path_edge(self, pin):
+        return self.path('gpio%d/edge' % pin)
+
     def export(self, pin):
         with self._lock:
-            if self._pin_refs[pin] == 0:
-                # Set the count to 1 to indicate the GPIO is already exported
-                # (we'll correct this if we find it isn't, but this enables us
-                # to "leave the system in the state we found it")
-                self._pin_refs[pin] = 1
+            try:
+                result = self._exports[pin]
+            except KeyError:
                 result = None
                 # Dirty hack to wait for udev to set permissions on
                 # gpioN/direction; there's no other way around this as there's
                 # no synchronous mechanism for setting permissions on sysfs
                 for i in range(10):
                     try:
-                        result = io.open(self.path('gpio%d/value' % pin), 'w+b', buffering=0)
+                        # Must be O_NONBLOCK for use with epoll in edge
+                        # triggered mode
+                        result = os.open(self.path_value(pin),
+                                         os.O_RDONLY | os.O_NONBLOCK)
                     except IOError as e:
                         if e.errno == errno.ENOENT:
-                            with io.open(self.path('export'), 'wb') as f:
+                            with io.open(self.path('export'), 'w+b') as f:
                                 f.write(str(pin).encode('ascii'))
-                            # Pin wasn't exported, so correct the ref-count
-                            self._pin_refs[pin] = 0
                         elif e.errno == errno.EACCES:
                             sleep(i / 100)
                         else:
                             raise
                     else:
+                        self._exports[pin] = result
                         break
-                if not result:
+                if result is None:
                     raise RuntimeError('failed to export pin %d' % pin)
-            else:
-                result = io.open(self.path('gpio%d/value' % pin), 'w+b', buffering=0)
-            self._pin_refs[pin] += 1
             return result
 
     def unexport(self, pin):
         with self._lock:
-            self._pin_refs[pin] -= 1
-            if self._pin_refs[pin] == 0:
-                with io.open(self.path('unexport'), 'wb') as f:
-                    f.write(str(pin).encode('ascii'))
+            try:
+                os.close(self._exports.pop(pin))
+            except KeyError:
+                # unexport should be idempotent
+                pass
+            else:
+                try:
+                    with io.open(self.path('unexport'), 'w+b') as f:
+                        f.write(str(pin).encode('ascii'))
+                except IOError as e:
+                    if e.errno == errno.EINVAL:
+                        # Someone already unexported it; ignore the error
+                        pass
+
+    def watch(self, pin):
+        with self._lock:
+            self._thread.watch(self.export(pin), pin)
+
+    def unwatch(self, pin):
+        with self._lock:
+            try:
+                self._thread.unwatch(self._exports[pin])
+            except KeyError:
+                pass
+
+
+class NativeWatchThread(Thread):
+    def __init__(self, factory, queue):
+        super(NativeWatchThread, self).__init__(
+            target=self._run, args=(factory, queue))
+        self._stop = Event()
+        # XXX Make this compatible with BSDs with poll() option?
+        self._epoll = select.epoll()
+        self._watches = {}
+        self.start()
+
+    def close(self):
+        self._stop.set()
+        self.join()
+        self._epoll.close()
+
+    def watch(self, fd, pin):
+        self._watches[fd] = pin
+        flags = select.EPOLLIN | select.EPOLLPRI | select.EPOLLET
+        self._epoll.register(fd, flags)
+
+    def unwatch(self, fd):
+        self._epoll.unregister(fd)
+        fd = self._watches.pop(fd, None)
+
+    def _run(self, factory, queue):
+        ticks = factory.ticks
+        while not self._stop.wait(0):
+            for fd, event in self._epoll.poll(0.01):
+                try:
+                    queue.put((ticks(), self._watches[fd]))
+                except KeyError:
+                    pass
+
+
+class NativeDispatchThread(Thread):
+    def __init__(self, factory, queue):
+        super(NativeDispatchThread, self).__init__(
+            target=self._run, args=(factory, queue))
+        self._stop = Event()
+        self.start()
+
+    def close(self):
+        self._stop.set()
+        self.join()
+
+    def _run(self, factory, queue):
+        pins = factory.pins
+        while not self._stop.wait(0):
+            try:
+                ticks, pin = queue.get(timeout=0.1)
+            except Empty:
+                continue
+            try:
+                pins[pin]._call_when_changed(ticks)
+            except KeyError:
+                pass
 
 
 class NativeFactory(LocalPiFactory):
@@ -169,12 +266,23 @@ class NativeFactory(LocalPiFactory):
     """
     def __init__(self):
         super(NativeFactory, self).__init__()
-        self.mem = GPIOMemory()
+        queue = Queue()
+        self.mem = GPIOMemory(self.pi_info.soc)
+        self.fs = GPIOFS(self, queue)
+        self.dispatch = NativeDispatchThread(self, queue)
         self.pin_class = NativePin
 
     def close(self):
+        if self.dispatch is not None:
+            self.dispatch.close()
+            self.dispatch = None
         super(NativeFactory, self).close()
-        self.mem.close()
+        if self.fs is not None:
+            self.fs.close()
+            self.fs = None
+        if self.mem is not None:
+            self.mem.close()
+            self.mem = None
 
 
 class NativePin(LocalPiPin):
@@ -199,16 +307,8 @@ class NativePin(LocalPiPin):
         'reserved': 0b11,
         }
 
-    GPIO_EDGES = {
-        'both':    (True,  True),
-        'rising':  (True,  False),
-        'falling': (False, True),
-        'none':    (False, False),
-        }
-
     GPIO_FUNCTION_NAMES = {v: k for (k, v) in GPIO_FUNCTIONS.items()}
     GPIO_PULL_UP_NAMES = {v: k for (k, v) in GPIO_PULL_UPS.items()}
-    GPIO_EDGES_NAMES = {v: k for (k, v) in GPIO_EDGES.items()}
 
     def __init__(self, factory, number):
         super(NativePin, self).__init__(factory, number)
@@ -232,11 +332,13 @@ class NativePin(LocalPiPin):
         self._change_thread = None
         self._change_event = Event()
         self.function = 'input'
+        self._pull = 'floating'
         self.pull = 'up' if self.factory.pi_info.pulled_up(repr(self)) else 'floating'
         self.bounce = None
-        self.edges = 'both'
+        self.edges = 'none'
 
     def close(self):
+        self.edges = 'none'
         self.frequency = None
         self.when_changed = None
         self.function = 'input'
@@ -288,48 +390,29 @@ class NativePin(LocalPiPin):
         self._pull = value
 
     def _get_edges(self):
-        rising = bool(self.factory.mem[self._rising_offset] & (1 << self._rising_shift))
-        falling = bool(self.factory.mem[self._falling_offset] & (1 << self._falling_shift))
-        return self.GPIO_EDGES_NAMES[(rising, falling)]
+        try:
+            with io.open(self.factory.fs.path_edge(self.number), 'r') as f:
+                return f.read().strip()
+        except IOError as e:
+            if e.errno == errno.ENOENT:
+                return 'none'
+            else:
+                raise
 
     def _set_edges(self, value):
+        if value != 'none':
+            self.factory.fs.export(self.number)
         try:
-            rising, falling = self.GPIO_EDGES[value]
-        except KeyError:
-            raise PinInvalidEdges('invalid edge specification "%s" for pin %r' % self)
-        f = self.when_changed
-        self.when_changed = None
-        try:
-            self.factory.mem[self._rising_offset] = (
-                self.factory.mem[self._rising_offset]
-                & ~(1 << self._rising_shift)
-                | (rising << self._rising_shift)
-                )
-            self.factory.mem[self._falling_offset] = (
-                self.factory.mem[self._falling_offset]
-                & ~(1 << self._falling_shift)
-                | (falling << self._falling_shift)
-                )
-        finally:
-            self.when_changed = f
+            with io.open(self.factory.fs.path_edge(self.number), 'w') as f:
+                f.write(value)
+        except IOError as e:
+            if e.errno == errno.EINVAL:
+                raise PinInvalidEdges('invalid edge specification "%s" for pin %r' % self)
+            else:
+                raise
 
     def _enable_event_detect(self):
-        self._change_thread = Thread(target=self._change_watch)
-        self._change_thread.daemon = True
-        self._change_event.clear()
-        self._change_thread.start()
+        self.factory.fs.watch(self.number)
 
     def _disable_event_detect(self):
-        self._change_event.set()
-        self._change_thread.join()
-        self._change_thread = None
-
-    def _change_watch(self):
-        offset = self._edge_offset
-        mask = 1 << self._edge_shift
-        self.factory.mem[offset] = mask # clear any existing detection bit
-        while not self._change_event.wait(0.001):
-            if self.factory.mem[offset] & mask:
-                self.factory.mem[offset] = mask
-                self._call_when_changed()
-
+        self.factory.fs.unwatch(self.number)

--- a/gpiozero/pins/native.py
+++ b/gpiozero/pins/native.py
@@ -189,6 +189,7 @@ class NativeWatchThread(Thread):
     def __init__(self, factory, queue):
         super(NativeWatchThread, self).__init__(
             target=self._run, args=(factory, queue))
+        self.daemon = True
         self._stop = Event()
         # XXX Make this compatible with BSDs with poll() option?
         self._epoll = select.epoll()
@@ -223,6 +224,7 @@ class NativeDispatchThread(Thread):
     def __init__(self, factory, queue):
         super(NativeDispatchThread, self).__init__(
             target=self._run, args=(factory, queue))
+        self.daemon = True
         self._stop = Event()
         self.start()
 

--- a/gpiozero/pins/native.py
+++ b/gpiozero/pins/native.py
@@ -127,6 +127,9 @@ class GPIOFS(object):
     def path_edge(self, pin):
         return self.path('gpio%d/edge' % pin)
 
+    def exported(self, pin):
+        return pin in self._exports
+
     def export(self, pin):
         with self._lock:
             try:
@@ -408,7 +411,9 @@ class NativePin(LocalPiPin):
             with io.open(self.factory.fs.path_edge(self.number), 'w') as f:
                 f.write(value)
         except IOError as e:
-            if e.errno == errno.EINVAL:
+            if e.errno == errno.ENOENT and value == 'none':
+                pass
+            elif e.errno == errno.EINVAL:
                 raise PinInvalidEdges('invalid edge specification "%s" for pin %r' % self)
             else:
                 raise

--- a/gpiozero/pins/native.py
+++ b/gpiozero/pins/native.py
@@ -139,7 +139,7 @@ class GPIOFS(object):
                 # Dirty hack to wait for udev to set permissions on
                 # gpioN/value; there's no other way around this as there's no
                 # synchronous mechanism for setting permissions on sysfs
-                for i in range(25):
+                for i in range(10):
                     try:
                         # Must be O_NONBLOCK for use with epoll in edge
                         # triggered mode
@@ -158,9 +158,9 @@ class GPIOFS(object):
                         break
                 # Same for gpioN/edge. It must exist by this point but the
                 # chmod -R may not have reached it yet...
-                for i in range(25):
+                for i in range(10):
                     try:
-                        with io.open(self.path_edge(pin), 'rb'):
+                        with io.open(self.path_edge(pin), 'w+b'):
                             pass
                     except IOError as e:
                         if e.errno == errno.EACCES:

--- a/gpiozero/pins/native.py
+++ b/gpiozero/pins/native.py
@@ -56,7 +56,7 @@ class GPIOMemory(object):
     GPPUD_OFFSET    = 0x94 >> 2
     GPPUDCLK_OFFSET = 0x98 >> 2
 
-    def __init__(self, rev):
+    def __init__(self, soc):
         try:
             self.fd = os.open('/dev/gpiomem', os.O_RDWR | os.O_SYNC)
         except OSError:
@@ -67,7 +67,7 @@ class GPIOMemory(object):
                     'unable to open /dev/gpiomem or /dev/mem; '
                     'upgrade your kernel or run as root')
             else:
-                offset = self.peripheral_base(rev) + self.GPIO_BASE_OFFSET
+                offset = self.peripheral_base(soc) + self.GPIO_BASE_OFFSET
         else:
             offset = 0
         self.mem = mmap.mmap(self.fd, 4096, offset=offset)
@@ -76,7 +76,7 @@ class GPIOMemory(object):
         self.mem.close()
         os.close(self.fd)
 
-    def peripheral_base(self, rev):
+    def peripheral_base(self, soc):
         try:
             with io.open('/proc/device-tree/soc/ranges', 'rb') as f:
                 f.seek(4)
@@ -84,7 +84,7 @@ class GPIOMemory(object):
                 return struct.unpack(nstr('>L'), f.read(4))[0]
         except IOError:
             try:
-                return self.PERI_BASE_OFFSET[rev]
+                return self.PERI_BASE_OFFSET[soc]
             except KeyError:
                 pass
         raise IOError('unable to determine peripheral base')

--- a/gpiozero/pins/native.py
+++ b/gpiozero/pins/native.py
@@ -262,7 +262,7 @@ class NativeDispatchThread(Thread):
                 pass
             else:
                 if (
-                        pin._last_call is None or pin._bounce is None or
+                        pin._bounce is None or pin._last_call is None or
                         factory.ticks_diff(ticks, pin._last_call) > pin._bounce
                 ):
                     pin._call_when_changed(ticks, state)
@@ -448,6 +448,7 @@ class NativePin(LocalPiPin):
 
     def _enable_event_detect(self):
         self.factory.fs.watch(self.number)
+        self._last_call = None
 
     def _disable_event_detect(self):
         self.factory.fs.unwatch(self.number)

--- a/gpiozero/pins/pi.py
+++ b/gpiozero/pins/pi.py
@@ -206,7 +206,7 @@ class PiPin(Pin):
     """
     Abstract base class representing a multi-function GPIO pin attached to a
     Raspberry Pi. This overrides several methods in the abstract base
-    :class:`~gpiozero.Pin`. Descendents must override the following methods:
+    :class:`~gpiozero.Pin`. Descendents *must* override the following methods:
 
     * :meth:`_get_function`
     * :meth:`_set_function`
@@ -255,7 +255,7 @@ class PiPin(Pin):
     def factory(self):
         return self._factory
 
-    def _call_when_changed(self):
+    def _call_when_changed(self, ticks):
         """
         Called to fire the :attr:`when_changed` event handler; override this
         in descendents if additional (currently redundant) parameters need
@@ -265,7 +265,7 @@ class PiPin(Pin):
         if method is None:
             self.when_changed = None
         else:
-            method()
+            method(ticks)
 
     def _get_when_changed(self):
         return self._when_changed

--- a/gpiozero/pins/pi.py
+++ b/gpiozero/pins/pi.py
@@ -255,7 +255,7 @@ class PiPin(Pin):
     def factory(self):
         return self._factory
 
-    def _call_when_changed(self, ticks):
+    def _call_when_changed(self, ticks, state):
         """
         Called to fire the :attr:`when_changed` event handler; override this
         in descendents if additional (currently redundant) parameters need
@@ -265,7 +265,7 @@ class PiPin(Pin):
         if method is None:
             self.when_changed = None
         else:
-            method(ticks)
+            method(ticks, state)
 
     def _get_when_changed(self):
         return self._when_changed
@@ -302,4 +302,3 @@ class PiPin(Pin):
         on pin :attr:`number`.
         """
         raise NotImplementedError
-

--- a/gpiozero/pins/pi.py
+++ b/gpiozero/pins/pi.py
@@ -261,14 +261,14 @@ class PiPin(Pin):
         in descendents if additional (currently redundant) parameters need
         to be passed.
         """
-        method = self.when_changed()
+        method = self._when_changed()
         if method is None:
             self.when_changed = None
         else:
             method(ticks, state)
 
     def _get_when_changed(self):
-        return self._when_changed
+        return None if self._when_changed is None else self._when_changed()
 
     def _set_when_changed(self, value):
         with self._when_changed_lock:

--- a/gpiozero/pins/pigpio.py
+++ b/gpiozero/pins/pigpio.py
@@ -140,7 +140,7 @@ class PiGPIOFactory(PiFactory):
         # modulo operator, unlike C's remainder) ensures the result is valid
         # even when later < earlier due to wrap-around (assuming the duration
         # measured is not longer than the period)
-        return (later - earlier) % 0x100000000
+        return ((later - earlier) % 0x100000000) / 1000000
 
 
 class PiGPIOPin(PiPin):
@@ -294,7 +294,7 @@ class PiGPIOPin(PiPin):
             self.when_changed = f
 
     def _call_when_changed(self, gpio, level, ticks):
-        super(PiGPIOPin, self)._call_when_changed(ticks)
+        super(PiGPIOPin, self)._call_when_changed(ticks, level)
 
     def _enable_event_detect(self):
         self._callback = self.factory.connection.callback(
@@ -543,4 +543,3 @@ class PiGPIOSoftwareSPIShared(SharedMixin, PiGPIOSoftwareSPI):
     @classmethod
     def _shared_key(cls, factory, clock_pin, mosi_pin, miso_pin, select_pin):
         return (factory, select_pin)
-

--- a/gpiozero/pins/pigpio.py
+++ b/gpiozero/pins/pigpio.py
@@ -134,7 +134,8 @@ class PiGPIOFactory(PiFactory):
     def ticks(self):
         return self._connection.get_current_tick()
 
-    def ticks_diff(self, later, earlier):
+    @staticmethod
+    def ticks_diff(later, earlier):
         # NOTE: pigpio ticks are unsigned 32-bit quantities that wrap every
         # 71.6 minutes. The modulo below (oh the joys of having an *actual*
         # modulo operator, unlike C's remainder) ensures the result is valid

--- a/gpiozero/pins/pigpio.py
+++ b/gpiozero/pins/pigpio.py
@@ -131,6 +131,17 @@ class PiGPIOFactory(PiFactory):
         self._spis.append(intf)
         return intf
 
+    def ticks(self):
+        return self._connection.get_current_tick()
+
+    def ticks_diff(self, later, earlier):
+        # NOTE: pigpio ticks are unsigned 32-bit quantities that wrap every
+        # 71.6 minutes. The modulo below (oh the joys of having an *actual*
+        # modulo operator, unlike C's remainder) ensures the result is valid
+        # even when later < earlier due to wrap-around (assuming the duration
+        # measured is not longer than the period)
+        return (later - earlier) % 0x100000000
+
 
 class PiGPIOPin(PiPin):
     """
@@ -282,8 +293,8 @@ class PiGPIOPin(PiPin):
         finally:
             self.when_changed = f
 
-    def _call_when_changed(self, gpio, level, tick):
-        super(PiGPIOPin, self)._call_when_changed()
+    def _call_when_changed(self, gpio, level, ticks):
+        super(PiGPIOPin, self)._call_when_changed(ticks)
 
     def _enable_event_detect(self):
         self._callback = self.factory.connection.callback(

--- a/gpiozero/pins/rpigpio.py
+++ b/gpiozero/pins/rpigpio.py
@@ -220,4 +220,3 @@ class RPiGPIOPin(LocalPiPin):
 
     def _disable_event_detect(self):
         GPIO.remove_event_detect(self.number)
-

--- a/gpiozero/pins/rpio.py
+++ b/gpiozero/pins/rpio.py
@@ -214,4 +214,3 @@ class RPIOPin(LocalPiPin):
             # simply means RPIO's built-in cleanup has already run and
             # removed the handler
             pass
-

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -157,7 +157,7 @@ def test_mock_pin_edges():
     assert pin.edges == 'both'
     pin.drive_low()
     assert not pin.state
-    def changed():
+    def changed(ticks, state):
         fired.set()
     pin.when_changed = changed
     pin.drive_high()

--- a/tests/test_spi.py
+++ b/tests/test_spi.py
@@ -8,6 +8,7 @@ nstr = str
 str = type('')
 
 
+import io
 import sys
 import pytest
 from array import array
@@ -32,7 +33,7 @@ def teardown_function(function):
 def test_spi_hardware_params():
     with patch('os.open'), patch('mmap.mmap') as mmap_mmap, patch('io.open') as io_open:
         mmap_mmap.return_value = array(nstr('B'), (0,) * 4096)
-        io_open.return_value.__enter__.return_value = ['Revision: a21042']
+        io_open.return_value.__enter__.return_value = io.BytesIO(b'\x00\xa2\x10\x42')
         factory = NativeFactory()
         with patch('gpiozero.pins.local.SpiDev'):
             with factory.spi() as device:
@@ -63,7 +64,7 @@ def test_spi_hardware_params():
 def test_spi_software_params():
     with patch('os.open'), patch('mmap.mmap') as mmap_mmap, patch('io.open') as io_open:
         mmap_mmap.return_value = array(nstr('B'), (0,) * 4096)
-        io_open.return_value.__enter__.return_value = ['Revision: a21042']
+        io_open.return_value.__enter__.return_value = io.BytesIO(b'\x00\xa2\x10\x42')
         factory = NativeFactory()
         with patch('gpiozero.pins.local.SpiDev'):
             with factory.spi(select_pin=6) as device:


### PR DESCRIPTION
Re-works the pins API to use timing information provided by underlying drivers (in particular pigpio) so that timing events from remote pins will be considerably more accurate (also seems to improve the accuracy of some local implementations too, probably because time sampling is done "closer" to the actual event).