### PR TITLE
I said import, damn it!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ develop-eggs
 
 # Installer logs
 pip-log.txt
+get-pip.py
 
 # Unit test / coverage reports
 coverage

--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -25,6 +25,9 @@ class BadQueueLen(GPIOZeroError, ValueError):
 class BadPinFactory(GPIOZeroError, ImportError):
     "Error raised when an unknown pin factory name is specified"
 
+class ZombieThread(GPIOZeroError, RuntimeError):
+    "Error raised when a thread fails to die within a given timeout"
+
 class CompositeDeviceError(GPIOZeroError):
     "Base class for errors specific to the CompositeDevice hierarchy"
 

--- a/gpiozero/threads.py
+++ b/gpiozero/threads.py
@@ -8,12 +8,20 @@ str = type('')
 
 from threading import Thread, Event
 
+from .exc import ZombieThread
+
 
 _THREADS = set()
 def _threads_shutdown():
     while _THREADS:
-        for t in _THREADS.copy():
-            t.stop()
+        threads = _THREADS.copy()
+        # Optimization: instead of calling stop() which implicitly calls
+        # join(), set all the stopping events simultaneously, *then* join
+        # threads with a reasonable timeout
+        for t in threads:
+            t.stopping.set()
+        for t in threads:
+            t.join(10)
 
 
 class GPIOThread(Thread):
@@ -29,11 +37,17 @@ class GPIOThread(Thread):
         _THREADS.add(self)
         super(GPIOThread, self).start()
 
-    def stop(self):
+    def stop(self, timeout=10):
         self.stopping.set()
-        self.join()
+        self.join(timeout)
 
-    def join(self):
-        super(GPIOThread, self).join()
-        _THREADS.discard(self)
-
+    def join(self, timeout=None):
+        super(GPIOThread, self).join(timeout)
+        if self.is_alive():
+            assert timeout is not None
+            # timeout can't be None here because if it was, then join()
+            # wouldn't return until the thread was dead
+            raise ZombieThread(
+                "Thread failed to die within %d seconds" % timeout)
+        else:
+            _THREADS.discard(self)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,5 +6,8 @@ from __future__ import (
     )
 str = type('')
 
-import os
-os.environ['GPIOZERO_PIN_FACTORY'] = 'mock'
+
+from gpiozero import Device
+from gpiozero.pins.mock import MockFactory
+
+Device.pin_factory = MockFactory()

--- a/tests/test_real_pins.py
+++ b/tests/test_real_pins.py
@@ -53,10 +53,8 @@ def pin_factory(request):
         pytest.skip("skipped factory %s: %s" % (request.param, str(e)))
     else:
         Device.pin_factory = factory
-        def fin():
-            Device.pin_factory = MockFactory()
-        request.addfinalizer(fin)
-        return factory
+        yield factory
+        Device.pin_factory = MockFactory()
 
 
 @pytest.fixture(scope='function')
@@ -71,11 +69,9 @@ def pins(request, pin_factory):
         test_pin = pin_factory.pin(TEST_PIN, pin_class=MockConnectedPin, input_pin=input_pin)
     else:
         test_pin = pin_factory.pin(TEST_PIN)
-    def fin():
-        test_pin.close()
-        input_pin.close()
-    request.addfinalizer(fin)
-    return test_pin, input_pin
+    yield test_pin, input_pin
+    test_pin.close()
+    input_pin.close()
 
 
 def test_pin_numbers(pins):

--- a/tests/test_real_pins.py
+++ b/tests/test_real_pins.py
@@ -39,7 +39,7 @@ TEST_PIN = int(os.getenv('GPIOZERO_TEST_PIN', '22'))
 INPUT_PIN = int(os.getenv('GPIOZERO_TEST_INPUT_PIN', '27'))
 
 
-@pytest.fixture(
+@pytest.yield_fixture(
     scope='module',
     params=[
         name
@@ -57,7 +57,7 @@ def pin_factory(request):
         Device.pin_factory = MockFactory()
 
 
-@pytest.fixture(scope='function')
+@pytest.yield_fixture(scope='function')
 def pins(request, pin_factory):
     # Why return both pins in a single fixture? If we defined one fixture for
     # each pin then pytest will (correctly) test RPiGPIOPin(22) against


### PR DESCRIPTION
Permit gpiozero to be imported without trying to load a pin factory; only load a pin factory on first Device construction. While we're at it re-work the default pin factory loader to avoid pkg_resources import in as many cases as possible (while keeping it around for third-party pin implementations). This is just because pkg_resources takes *ages* to load (especially on an I/O limited platform like the Pi).

Fixes #600 and #675 