### PR TITLE
Coverage boost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ develop-eggs
 
 # Installer logs
 pip-log.txt
-get-pip.py
+get-pip*.py
 
 # Unit test / coverage reports
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ get-pip.py
 
 # Unit test / coverage reports
 coverage
-.coverage
+.coverage*
 .tox
 .cache
 .pytest_cache

--- a/gpiozero/compat.py
+++ b/gpiozero/compat.py
@@ -13,7 +13,7 @@ import weakref
 import operator
 import functools
 
-# Handles pre 3.3 versions of Python withoout collections.abc
+# Handles pre 3.3 versions of Python without collections.abc
 try:
     from collections.abc import Mapping
 except ImportError:
@@ -141,4 +141,3 @@ class WeakMethod(weakref.ref):
         return True
 
     __hash__ = weakref.ref.__hash__
-

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -208,9 +208,7 @@ class Device(ValuesMixin, GPIOBase):
         super(Device, self).__init__()
 
     @staticmethod
-    def _default_pin_factory(name=None):
-        if name is None:
-            name = os.getenv('GPIOZERO_PIN_FACTORY', None)
+    def _default_pin_factory():
         # We prefer RPi.GPIO here as it supports PWM, and all Pi revisions.  If
         # no third-party libraries are available, however, we fall back to a
         # pure Python implementation which supports platforms like PyPy
@@ -223,6 +221,7 @@ class Device(ValuesMixin, GPIOBase):
             'pigpio':  'gpiozero.pins.pigpio:PiGPIOFactory',
             'native':  'gpiozero.pins.native:NativeFactory',
         })
+        name = os.environ.get('GPIOZERO_PIN_FACTORY')
         if name is None:
             # If no factory is explicitly specified, try various names in
             # "preferred" order. For speed, we select from the dictionary above

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -208,7 +208,9 @@ class Device(ValuesMixin, GPIOBase):
         super(Device, self).__init__()
 
     @staticmethod
-    def _default_pin_factory(name=os.getenv('GPIOZERO_PIN_FACTORY', None)):
+    def _default_pin_factory(name=None):
+        if name is None:
+            name = os.getenv('GPIOZERO_PIN_FACTORY', None)
         # We prefer RPi.GPIO here as it supports PWM, and all Pi revisions.  If
         # no third-party libraries are available, however, we fall back to a
         # pure Python implementation which supports platforms like PyPy

--- a/gpiozero/mixins.py
+++ b/gpiozero/mixins.py
@@ -68,14 +68,8 @@ class SourceMixin(object):
         super(SourceMixin, self).__init__(*args, **kwargs)
 
     def close(self):
-        try:
-            self.source = None
-        except AttributeError:
-            pass
-        try:
-            super(SourceMixin, self).close()
-        except AttributeError:
-            pass
+        self.source = None
+        super(SourceMixin, self).close()
 
     def _copy_values(self, source):
         for v in source:
@@ -348,13 +342,10 @@ class HoldMixin(EventsMixin):
         self._hold_thread = HoldThread(self)
 
     def close(self):
-        if getattr(self, '_hold_thread', None):
+        if self._hold_thread is not None:
             self._hold_thread.stop()
         self._hold_thread = None
-        try:
-            super(HoldMixin, self).close()
-        except AttributeError:
-            pass
+        super(HoldMixin, self).close()
 
     def _fire_activated(self):
         super(HoldMixin, self)._fire_activated()
@@ -504,7 +495,7 @@ class GPIOQueue(GPIOThread):
             self.full.wait()
         try:
             return self.average(self.queue)
-        except ZeroDivisionError:
+        except (ZeroDivisionError, ValueError):
             # No data == inactive value
             return 0.0
 

--- a/gpiozero/pins/__init__.py
+++ b/gpiozero/pins/__init__.py
@@ -87,14 +87,13 @@ class Factory(object):
         Releases all pin reservations taken out by *reserver*. See
         :meth:`release_pins` for further information).
         """
-        with self._res_lock:
-            self._reservations = defaultdict(list, {
-                pin: [
-                    ref for ref in conflictors
-                    if ref() not in (reserver, None)
-                    ]
-                for pin, conflictors in self._reservations.items()
-                })
+        # Yes, this would be more efficient if it simply regenerated the
+        # reservations list without any references to reserver instead of
+        # (in release_pins) looping over each pin individually. However, this
+        # then causes a subtle bug in LocalPiFactory which does something
+        # horribly naughty (with good reason) and makes its _reservations
+        # dictionary equivalent to a class-level one.
+        self.release_pins(reserver, *self._reservations)
 
     def close(self):
         """

--- a/gpiozero/pins/local.py
+++ b/gpiozero/pins/local.py
@@ -132,7 +132,7 @@ class LocalPiHardwareSPI(SPI, Device):
         self._interface.max_speed_hz = 500000
 
     def close(self):
-        if getattr(self, '_interface', None):
+        if self._interface is not None:
             self._interface.close()
         self._interface = None
         self.pin_factory.release_all(self)
@@ -203,7 +203,7 @@ class LocalPiSoftwareSPI(SPI, OutputDevice):
             )
 
     def close(self):
-        if getattr(self, '_bus', None):
+        if self._bus is not None:
             self._bus.close()
         self._bus = None
         super(LocalPiSoftwareSPI, self).close()

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -24,6 +24,7 @@ from ..exc import (
     PinFixedPull,
     PinInvalidFunction,
     PinInvalidPull,
+    PinInvalidBounce,
     )
 from ..devices import Device
 from .local import LocalPiPin, LocalPiFactory
@@ -108,6 +109,11 @@ class MockPin(LocalPiPin):
 
     def _set_bounce(self, value):
         # XXX Need to implement this
+        if value is not None:
+            try:
+                value = float(value)
+            except ValueError:
+                raise PinInvalidBounce('bounce must be None or a float')
         self._bounce = value
 
     def _get_edges(self):

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -417,10 +417,12 @@ class MockFactory(LocalPiFactory):
     by the :meth:`pin` method by default. This can be changed after
     construction by modifying the :attr:`pin_class` attribute.
     """
-    def __init__(
-            self, revision=os.getenv('GPIOZERO_MOCK_REVISION', 'a02082'),
-            pin_class=os.getenv('GPIOZERO_MOCK_PIN_CLASS', MockPin)):
+    def __init__(self, revision=None, pin_class=None):
         super(MockFactory, self).__init__()
+        if revision is None:
+            revision = os.environ.get('GPIOZERO_MOCK_REVISION', 'a02082')
+        if pin_class is None:
+            pin_class = os.environ.get('GPIOZERO_MOCK_PIN_CLASS', MockPin)
         self._revision = revision
         if isinstance(pin_class, bytes):
             pin_class = pin_class.decode('ascii')

--- a/gpiozero/pins/pigpio.py
+++ b/gpiozero/pins/pigpio.py
@@ -72,10 +72,13 @@ class PiGPIOFactory(PiFactory):
 
     .. _pigpio: http://abyz.co.uk/rpi/pigpio/
     """
-    def __init__(
-            self, host=os.getenv('PIGPIO_ADDR', 'localhost'),
-            port=int(os.getenv('PIGPIO_PORT', 8888))):
+    def __init__(self, host=None, port=None):
         super(PiGPIOFactory, self).__init__()
+        if host is None:
+            host = os.environ.get('PIGPIO_ADDR', 'localhost')
+        if port is None:
+            # XXX Use getservbyname
+            port = int(os.environ.get('PIGPIO_PORT', 8888))
         self.pin_class = PiGPIOPin
         self.spi_classes = {
             ('hardware', 'exclusive'): PiGPIOHardwareSPI,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
+import io
 import os
 import sys
+import errno
 from setuptools import setup, find_packages
 
 "A simple interface to GPIO devices with Raspberry Pi."
@@ -71,6 +73,17 @@ if sys.version_info[:2] == (3, 2):
 elif sys.version_info[:2] == (3, 3):
     # Particular versions are required for Python 3.3 compatibility
     __extra_requires__['test'][0] = 'pytest<3.3dev'
+
+try:
+    # If we're executing on a Raspberry Pi, install all GPIO libraries for
+    # testing (except RPIO which doesn't work on the multi-core models yet)
+    with io.open('/proc/device-tree/model', 'r') as f:
+        if f.read().startswith('Raspberry Pi'):
+            __extra_requires__['test'].append('RPi.GPIO')
+            __extra_requires__['test'].append('pigpio')
+except IOError as e:
+    if e.errno != errno.ENOENT:
+        raise
 
 __entry_points__ = {
     'gpiozero_pin_factories': [

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,9 @@ if sys.version_info[:2] == (3, 2):
     __extra_requires__['test'][0] = 'pytest<3.0dev'
     __extra_requires__['test'][1] = 'coverage<4.0dev'
 elif sys.version_info[:2] == (3, 3):
-    # Particular versions are required for Python 3.3 compatibility
     __extra_requires__['test'][0] = 'pytest<3.3dev'
+elif sys.version_info[:2] == (3, 4):
+    __extra_requires__['test'][0] = 'pytest<5.0dev'
 
 try:
     # If we're executing on a Raspberry Pi, install all GPIO libraries for

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,8 @@ def mock_factory(request):
     # This reset() may seem redundant given we're re-constructing the factory
     # for each function that requires is but MockFactory (via LocalFactory)
     # stores some info at the class level which reset() clears.
-    Device.pin_factory.reset()
+    if Device.pin_factory is not None:
+        Device.pin_factory.reset()
     Device.pin_factory = save_factory
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,6 @@ def mock_factory(request):
     Device.pin_factory.reset()
     Device.pin_factory = save_factory
 
-@pytest.yield_fixture()
+@pytest.fixture()
 def pwm(request, mock_factory):
     mock_factory.pin_class = MockPWMPin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,23 @@ from __future__ import (
 str = type('')
 
 
-from gpiozero import Device
-from gpiozero.pins.mock import MockFactory
+import pytest
 
-Device.pin_factory = MockFactory()
+from gpiozero import Device
+from gpiozero.pins.mock import MockFactory, MockPWMPin
+
+
+@pytest.yield_fixture(scope='function')
+def mock_factory(request):
+    save_factory = Device.pin_factory
+    Device.pin_factory = MockFactory()
+    yield Device.pin_factory
+    # This reset() may seem redundant given we're re-constructing the factory
+    # for each function that requires is but MockFactory (via LocalFactory)
+    # stores some info at the class level which reset() clears.
+    Device.pin_factory.reset()
+    Device.pin_factory = save_factory
+
+@pytest.yield_fixture()
+def pwm(request, mock_factory):
+    mock_factory.pin_class = MockPWMPin

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -7,11 +7,32 @@ from __future__ import (
 str = type('')
 
 
+import gc
 import pytest
 import random
+import weakref
 
 from gpiozero.compat import *
 
+
+def test_frozendict():
+    d = {1: 'a', 2: 'b'}
+    e = {1: 'a', 2: 'b', 'foo': 'bar'}
+    f = frozendict(d)
+    assert f[1] == 'a'
+    assert f[2] == 'b'
+    with pytest.raises(KeyError):
+        f[3]
+    with pytest.raises(TypeError):
+        f[3] = 'c'
+    assert d == f
+    assert d == f.copy()
+    assert e == f.copy(foo='bar')
+    assert len(f) == 2
+    assert {k: v for k, v in f.items()} == d
+    h = hash(f)
+    assert h is not None
+    assert hash(f) == h
 
 # ported from the official test cases; see
 # https://github.com/python/cpython/blob/master/Lib/test/test_math.py for original
@@ -147,3 +168,165 @@ def test_median_empty():
     with pytest.raises(ValueError):
         median(())
 
+# ported from the official test cases; see
+# https://github.com/python/cpython/blob/master/Lib/test/test_weakref.py for
+# original
+
+class Object(object):
+    def __init__(self, arg):
+        self.arg = arg
+    def __repr__(self):
+        return "<Object %r>" % self.arg
+    def __eq__(self, other):
+        if isinstance(other, Object):
+            return self.arg == other.arg
+        return NotImplemented
+    def __ne__(self, other):
+        if isinstance(other, Object):
+            return self.arg != other.arg
+        return NotImplemented
+    def __lt__(self, other):
+        if isinstance(other, Object):
+            return self.arg < other.arg
+        return NotImplemented
+    def __hash__(self):
+        return hash(self.arg)
+    def some_method(self):
+        return 4
+    def other_method(self):
+        return 5
+
+@pytest.fixture()
+def subclass(request):
+    class C(Object):
+        def some_method(self):
+            return 6
+    return C
+
+
+def test_weakmethod_alive():
+    o = Object(1)
+    r = WeakMethod(o.some_method)
+    assert isinstance(r, weakref.ReferenceType)
+    assert isinstance(r(), type(o.some_method))
+    assert r().__self__ is o
+    assert r().__func__ is o.some_method.__func__
+    assert r()() == 4
+
+def test_weakmethod_object_dead():
+    o = Object(1)
+    r = WeakMethod(o.some_method)
+    del o
+    gc.collect()
+    assert r() is None
+
+def test_weakmethod_method_dead(subclass):
+    o = subclass(1)
+    r = WeakMethod(o.some_method)
+    del subclass.some_method
+    gc.collect()
+    assert r() is None
+
+def test_weakmethod_callback_when_object_dead(subclass):
+    calls = []
+    def cb(arg):
+        calls.append(arg)
+    o = subclass(1)
+    r = WeakMethod(o.some_method, cb)
+    del o
+    gc.collect()
+    assert calls == [r]
+    # Callback is only called once
+    subclass.some_method = Object.some_method
+    gc.collect()
+    assert calls == [r]
+
+def test_weakmethod_callback_when_method_dead(subclass):
+    calls = []
+    def cb(arg):
+        calls.append(arg)
+    o = subclass(1)
+    r = WeakMethod(o.some_method, cb)
+    del subclass.some_method
+    gc.collect()
+    assert calls == [r]
+    # Callback is only called once
+    del o
+    gc.collect()
+    assert calls == [r]
+
+def test_weakmethod_no_cycles():
+    o = Object(1)
+    def cb(_):
+        pass
+    r = WeakMethod(o.some_method, cb)
+    wr = weakref.ref(r)
+    del r
+    assert wr() is None
+
+def test_weakmethod_equality():
+    def _eq(a, b):
+        assert a == b
+        assert not (a != b)
+    def _ne(a, b):
+        assert not (a == b)
+        assert a != b
+    x = Object(1)
+    y = Object(1)
+    a = WeakMethod(x.some_method)
+    b = WeakMethod(y.some_method)
+    c = WeakMethod(x.other_method)
+    d = WeakMethod(y.other_method)
+    # Objects equal, same method
+    _eq(a, b)
+    _eq(c, d)
+    # Objects equal, different method
+    _ne(a, c)
+    _ne(a, d)
+    _ne(b, c)
+    _ne(b, d)
+    # Objects unequal, same or different method
+    z = Object(2)
+    e = WeakMethod(z.some_method)
+    f = WeakMethod(z.other_method)
+    _ne(a, e)
+    _ne(a, f)
+    _ne(b, e)
+    _ne(b, f)
+    del x, y, z
+    gc.collect()
+    # Dead WeakMethods compare by identity
+    refs = a, b, c, d, e, f
+    for q in refs:
+        for r in refs:
+            assert (q == r) == (q is r)
+            assert (q != r) == (q is not r)
+
+def test_weakmethod_hashing():
+    x = Object(1)
+    y = Object(1)
+    a = WeakMethod(x.some_method)
+    b = WeakMethod(y.some_method)
+    c = WeakMethod(y.other_method)
+    # Since WeakMethod objects are equal, the hashes should be equal
+    assert hash(a) == hash(b)
+    ha = hash(a)
+    # Dead WeakMethods retain their old hash value
+    del x, y
+    gc.collect()
+    assert hash(a) == ha
+    assert hash(b) == ha
+    # If it wasn't hashed when alive, a dead WeakMethod cannot be hashed
+    with pytest.raises(TypeError):
+        hash(c)
+
+def test_weakmethod_bad_method():
+    with pytest.raises(TypeError):
+        WeakMethod('foo')
+
+def test_weakmethod_other_equality():
+    x = Object(1)
+    a = WeakMethod(x.some_method)
+    b = WeakMethod(x.other_method)
+    assert not a == 1
+    assert a != 1

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -8,6 +8,7 @@ str = type('')
 
 
 import gc
+import sys
 import pytest
 import random
 import weakref
@@ -220,6 +221,7 @@ def test_weakmethod_object_dead():
     gc.collect()
     assert r() is None
 
+@pytest.mark.xfail(sys.version_info[:2] == (3, 2), reason='fails on py3.2')
 def test_weakmethod_method_dead(subclass):
     o = subclass(1)
     r = WeakMethod(o.some_method)
@@ -241,6 +243,7 @@ def test_weakmethod_callback_when_object_dead(subclass):
     gc.collect()
     assert calls == [r]
 
+@pytest.mark.xfail(sys.version_info[:2] == (3, 2), reason='fails on py3.2')
 def test_weakmethod_callback_when_method_dead(subclass):
     calls = []
     def cb(arg):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -221,7 +221,8 @@ def test_weakmethod_object_dead():
     gc.collect()
     assert r() is None
 
-@pytest.mark.xfail(sys.version_info[:2] == (3, 2), reason='fails on py3.2')
+@pytest.mark.xfail((3, 2) <= sys.version_info[:2] <= (3, 3),
+                   reason='intermittent failure on py3.2 and py3.3')
 def test_weakmethod_method_dead(subclass):
     o = subclass(1)
     r = WeakMethod(o.some_method)
@@ -243,7 +244,8 @@ def test_weakmethod_callback_when_object_dead(subclass):
     gc.collect()
     assert calls == [r]
 
-@pytest.mark.xfail(sys.version_info[:2] == (3, 2), reason='fails on py3.2')
+@pytest.mark.xfail((3, 2) <= sys.version_info[:2] <= (3, 3),
+                   reason='intermittent failure on py3.2 and py3.3')
 def test_weakmethod_callback_when_method_dead(subclass):
     calls = []
     def cb(arg):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -260,6 +260,8 @@ def test_weakmethod_callback_when_method_dead(subclass):
     gc.collect()
     assert calls == [r]
 
+@pytest.mark.xfail(hasattr(sys, 'pypy_version_info'),
+                   reason='pypy memory management is different')
 def test_weakmethod_no_cycles():
     o = Object(1)
     def cb(_):

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -9,6 +9,7 @@ str = type('')
 import os
 import warnings
 
+import mock
 import pytest
 
 from gpiozero import *
@@ -168,3 +169,5 @@ def test_shutdown(mock_factory):
     assert ds.closed
     assert not f.pins
     assert Device.pin_factory is None
+    # Shutdown must be idempotent
+    _shutdown()

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -109,6 +109,12 @@ def test_device_unknown_attr(mock_factory):
         with pytest.raises(AttributeError):
             device.foo = 1
 
+def test_device_broken_attr(mock_factory):
+    with GPIODevice(2) as device:
+        del device._active_state
+        with pytest.raises(AttributeError):
+            device.value
+
 def test_device_context_manager(mock_factory):
     with GPIODevice(2) as device:
         assert not device.closed
@@ -153,3 +159,12 @@ def test_composite_device_read_only(mock_factory):
     with CompositeDevice(foo=InputDevice(4), bar=InputDevice(5)) as device:
         with pytest.raises(AttributeError):
             device.foo = 1
+
+def test_shutdown(mock_factory):
+    from gpiozero.devices import _shutdown
+    ds = DistanceSensor(17, 19)
+    f = Device.pin_factory
+    _shutdown()
+    assert ds.closed
+    assert not f.pins
+    assert Device.pin_factory is None

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -16,12 +16,9 @@ from gpiozero.pins.mock import MockChargingPin, MockTriggerPin
 from gpiozero import *
 
 
-def teardown_function(function):
-    Device.pin_factory.reset()
 
-
-def test_input_initial_values():
-    pin = Device.pin_factory.pin(4)
+def test_input_initial_values(mock_factory):
+    pin = mock_factory.pin(4)
     with InputDevice(4, pull_up=True) as device:
         assert pin.function == 'input'
         assert pin.pull == 'up'
@@ -30,8 +27,8 @@ def test_input_initial_values():
         assert pin.pull == 'down'
         assert not device.pull_up
 
-def test_input_is_active_low():
-    pin = Device.pin_factory.pin(2)
+def test_input_is_active_low(mock_factory):
+    pin = mock_factory.pin(2)
     with InputDevice(2, pull_up=True) as device:
         pin.drive_high()
         assert not device.is_active
@@ -40,8 +37,8 @@ def test_input_is_active_low():
         assert device.is_active
         assert repr(device) == '<gpiozero.InputDevice object on pin GPIO2, pull_up=True, is_active=True>'
 
-def test_input_is_active_high():
-    pin = Device.pin_factory.pin(4)
+def test_input_is_active_high(mock_factory):
+    pin = mock_factory.pin(4)
     with InputDevice(4, pull_up=False) as device:
         pin.drive_high()
         assert device.is_active
@@ -50,23 +47,23 @@ def test_input_is_active_high():
         assert not device.is_active
         assert repr(device) == '<gpiozero.InputDevice object on pin GPIO4, pull_up=False, is_active=False>'
 
-def test_input_pulled_up():
-    pin = Device.pin_factory.pin(2)
+def test_input_pulled_up(mock_factory):
+    pin = mock_factory.pin(2)
     with pytest.raises(PinFixedPull):
         InputDevice(2, pull_up=False)
 
-def test_input_event_activated():
+def test_input_event_activated(mock_factory):
     event = Event()
-    pin = Device.pin_factory.pin(4)
+    pin = mock_factory.pin(4)
     with DigitalInputDevice(4) as device:
         device.when_activated = lambda: event.set()
         assert not event.is_set()
         pin.drive_high()
         assert event.is_set()
 
-def test_input_event_deactivated():
+def test_input_event_deactivated(mock_factory):
     event = Event()
-    pin = Device.pin_factory.pin(4)
+    pin = mock_factory.pin(4)
     with DigitalInputDevice(4) as device:
         device.when_deactivated = lambda: event.set()
         assert not event.is_set()
@@ -75,9 +72,9 @@ def test_input_event_deactivated():
         pin.drive_low()
         assert event.is_set()
 
-def test_input_partial_callback():
+def test_input_partial_callback(mock_factory):
     event = Event()
-    pin = Device.pin_factory.pin(4)
+    pin = mock_factory.pin(4)
     def foo(a, b):
         event.set()
         return a + b
@@ -89,21 +86,21 @@ def test_input_partial_callback():
         pin.drive_high()
         assert event.is_set()
 
-def test_input_wait_active():
-    pin = Device.pin_factory.pin(4)
+def test_input_wait_active(mock_factory):
+    pin = mock_factory.pin(4)
     with DigitalInputDevice(4) as device:
         pin.drive_high()
         assert device.wait_for_active(1)
         assert not device.wait_for_inactive(0)
 
-def test_input_wait_inactive():
-    pin = Device.pin_factory.pin(4)
+def test_input_wait_inactive(mock_factory):
+    pin = mock_factory.pin(4)
     with DigitalInputDevice(4) as device:
         assert device.wait_for_inactive(1)
         assert not device.wait_for_active(0)
 
-def test_input_smoothed_attrib():
-    pin = Device.pin_factory.pin(4)
+def test_input_smoothed_attrib(mock_factory):
+    pin = mock_factory.pin(4)
     with SmoothedInputDevice(4, threshold=0.5, queue_len=5, partial=False) as device:
         assert repr(device) == '<gpiozero.SmoothedInputDevice object on pin GPIO4, pull_up=False>'
         assert device.threshold == 0.5
@@ -114,8 +111,8 @@ def test_input_smoothed_attrib():
         with pytest.raises(InputDeviceError):
             device.threshold = 1
 
-def test_input_smoothed_values():
-    pin = Device.pin_factory.pin(4)
+def test_input_smoothed_values(mock_factory):
+    pin = mock_factory.pin(4)
     with SmoothedInputDevice(4) as device:
         device._queue.start()
         assert not device.is_active
@@ -124,8 +121,8 @@ def test_input_smoothed_values():
         pin.drive_low()
         assert device.wait_for_inactive(1)
 
-def test_input_button():
-    pin = Device.pin_factory.pin(2)
+def test_input_button(mock_factory):
+    pin = mock_factory.pin(2)
     with Button(2) as button:
         assert pin.pull == 'up'
         assert not button.is_pressed
@@ -136,8 +133,8 @@ def test_input_button():
         assert not button.is_pressed
         assert button.wait_for_release(1)
 
-def test_input_line_sensor():
-    pin = Device.pin_factory.pin(4)
+def test_input_line_sensor(mock_factory):
+    pin = mock_factory.pin(4)
     with LineSensor(4) as sensor:
         pin.drive_low() # logic is inverted for line sensor
         assert sensor.wait_for_line(1)
@@ -146,8 +143,8 @@ def test_input_line_sensor():
         assert sensor.wait_for_no_line(1)
         assert not sensor.line_detected
 
-def test_input_motion_sensor():
-    pin = Device.pin_factory.pin(4)
+def test_input_motion_sensor(mock_factory):
+    pin = mock_factory.pin(4)
     with MotionSensor(4) as sensor:
         pin.drive_high()
         assert sensor.wait_for_motion(1)
@@ -158,8 +155,9 @@ def test_input_motion_sensor():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_input_light_sensor():
-    pin = Device.pin_factory.pin(4, pin_class=MockChargingPin)
+def test_input_light_sensor(mock_factory):
+    pin = mock_factory.pin(4, pin_class=MockChargingPin)
+    assert isinstance(pin, MockChargingPin)
     with LightSensor(4) as sensor:
         pin.charge_time = 0.1
         assert sensor.wait_for_dark(1)
@@ -168,9 +166,10 @@ def test_input_light_sensor():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_input_distance_sensor():
-    echo_pin = Device.pin_factory.pin(4)
-    trig_pin = Device.pin_factory.pin(5, pin_class=MockTriggerPin, echo_pin=echo_pin, echo_time=0.02)
+def test_input_distance_sensor(mock_factory):
+    echo_pin = mock_factory.pin(4)
+    trig_pin = mock_factory.pin(5, pin_class=MockTriggerPin,
+                                echo_pin=echo_pin, echo_time=0.02)
     with pytest.raises(ValueError):
         DistanceSensor(4, 5, max_distance=-1)
     # normal queue len is large (because the sensor is *really* jittery) but
@@ -181,11 +180,13 @@ def test_input_distance_sensor():
         assert sensor.echo is echo_pin
         assert sensor.wait_for_out_of_range(1)
         assert not sensor.in_range
-        assert sensor.distance == 1.0 # should be waay before max-distance so this should work
+        # should be waay before max-distance so this should work
+        assert sensor.distance == 1.0
         trig_pin.echo_time = 0.0
         assert sensor.wait_for_in_range(1)
         assert sensor.in_range
-        assert sensor.distance < sensor.threshold_distance # depending on speed of machine, may not reach 0 here
+        # depending on speed of machine, may not reach 0 here
+        assert sensor.distance < sensor.threshold_distance
         sensor.threshold_distance = 0.1
         assert sensor.threshold_distance == 0.1
         with pytest.raises(ValueError):
@@ -193,4 +194,3 @@ def test_input_distance_sensor():
         sensor.max_distance = 20
         assert sensor.max_distance == 20
         assert sensor.threshold_distance == 0.1
-

--- a/tests/test_internal_devices.py
+++ b/tests/test_internal_devices.py
@@ -20,7 +20,7 @@ from datetime import datetime, time
 file_not_found = IOError(errno.ENOENT, 'File not found')
 bad_ping = CalledProcessError(1, 'returned non-zero exit status 1')
 
-def test_timeofday_bad_init():
+def test_timeofday_bad_init(mock_factory):
     with pytest.raises(TypeError):
          TimeOfDay()
     with pytest.raises(ValueError):
@@ -38,7 +38,7 @@ def test_timeofday_bad_init():
     with pytest.raises(ValueError):
         TimeOfDay(datetime(2019, 1, 24, 19), time(19))  # lurch edge case
 
-def test_timeofday_init():
+def test_timeofday_init(mock_factory):
     TimeOfDay(time(7), time(8), utc=False)
     TimeOfDay(time(7), time(8), utc=True)
     TimeOfDay(time(0), time(23, 59))
@@ -49,7 +49,7 @@ def test_timeofday_init():
     TimeOfDay(time(18), time(6))
     TimeOfDay(datetime(2019, 1, 24, 19), time(19, 1))  # lurch edge case
 
-def test_timeofday_value():
+def test_timeofday_value(mock_factory):
     with TimeOfDay(time(7), time(8), utc=False) as tod:
         assert tod.start_time == time(7)
         assert tod.end_time == time(8)
@@ -114,11 +114,11 @@ def test_timeofday_value():
             dt.utcnow.return_value = datetime(2018, 1, 2, 6, 0, 0)
             assert tod.is_active
 
-def test_pingserver_bad_init():
+def test_pingserver_bad_init(mock_factory):
     with pytest.raises(TypeError):
          PingServer()
 
-def test_pingserver_init():
+def test_pingserver_init(mock_factory):
     with patch('gpiozero.internal_devices.subprocess') as sp:
         sp.check_call.return_value = True
         with PingServer('example.com') as server:
@@ -130,7 +130,7 @@ def test_pingserver_init():
         with PingServer('2001:4860:4860::8888') as server:
             assert server.host == '2001:4860:4860::8888'
 
-def test_pingserver_value():
+def test_pingserver_value(mock_factory):
     with patch('gpiozero.internal_devices.subprocess.check_call') as check_call:
         with PingServer('example.com') as server:
             assert server.is_active
@@ -139,7 +139,7 @@ def test_pingserver_value():
             check_call.side_effect = None
             assert server.is_active
 
-def test_cputemperature_bad_init():
+def test_cputemperature_bad_init(mock_factory):
     with patch('io.open') as m:
         m.return_value.__enter__.side_effect = file_not_found
         with pytest.raises(IOError):
@@ -156,7 +156,7 @@ def test_cputemperature_bad_init():
         with pytest.raises(ValueError):
             CPUTemperature(min_temp=20, max_temp=10)
 
-def test_cputemperature():
+def test_cputemperature(mock_factory):
     with patch('io.open') as m:
         m.return_value.__enter__.return_value.readline.return_value = '37000'
         with CPUTemperature() as cpu:
@@ -172,7 +172,7 @@ def test_cputemperature():
         with CPUTemperature(min_temp=30, max_temp=40, threshold=35) as cpu:
             assert cpu.is_active
 
-def test_loadaverage_bad_init():
+def test_loadaverage_bad_init(mock_factory):
     with patch('io.open') as m:
         foo = m.return_value.__enter__
         foo.side_effect = file_not_found
@@ -194,7 +194,7 @@ def test_loadaverage_bad_init():
         with pytest.raises(ValueError):
             LoadAverage(minutes=10)
 
-def test_loadaverage():
+def test_loadaverage(mock_factory):
     with patch('io.open') as m:
         foo = m.return_value.__enter__
         foo.return_value.readline.return_value = '0.09 0.10 0.09 1/292 20758'
@@ -221,18 +221,18 @@ def test_loadaverage():
                 assert w[0].category == ThresholdOutOfRange
                 assert la.load_average == 1.4
 
-def test_diskusage_bad_init():
+def test_diskusage_bad_init(mock_factory):
     with pytest.raises(ValueError):
         DiskUsage(filesystem='badfilesystem')
 
-def test_diskusage_init():
+def test_diskusage_init(mock_factory):
     with patch('gpiozero.internal_devices.os.path') as ospath:
         ospath.ismount.return_value = True
         with DiskUsage('/home') as disk:
             assert disk.filesystem == '/home'
             assert disk.threshold == 90.0
 
-def test_diskusage():
+def test_diskusage(mock_factory):
     with patch('gpiozero.internal_devices.subprocess.Popen.communicate') as communicate:
         communicate.return_value = (b'Use%\n 52%\n', None)
         with DiskUsage() as disk:

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,0 +1,106 @@
+from __future__ import (
+    unicode_literals,
+    absolute_import,
+    print_function,
+    division,
+    )
+str = type('')
+
+
+import gc
+import sys
+from time import sleep
+from threading import Event
+
+import pytest
+
+from gpiozero import *
+
+
+def test_source_delay(mock_factory):
+    with OutputDevice(2) as device:
+        device.source_delay = 1
+        assert device.source_delay == 1
+        device.source_delay = 0.1
+        assert device.source_delay == 0.1
+        with pytest.raises(ValueError):
+            device.source_delay = -1
+
+
+def test_source(mock_factory):
+    pin = mock_factory.pin(4)
+    with InputDevice(4) as in_dev, OutputDevice(3) as out_dev:
+        assert out_dev.source is None
+        out_dev.source = in_dev.values
+        assert out_dev.source is not None
+        assert out_dev.value == 0
+        pin.drive_high()
+        # Give the output device some time to read the input device state
+        sleep(0.1)
+        assert out_dev.value == 1
+
+
+def test_active_time(mock_factory):
+    pin = mock_factory.pin(4)
+    with DigitalInputDevice(4) as dev:
+        assert dev.active_time is None
+        assert dev.inactive_time >= 0.0
+        pin.drive_high()
+        sleep(0.1)
+        assert dev.active_time >= 0.1
+        assert dev.inactive_time is None
+        pin.drive_low()
+        sleep(0.1)
+        assert dev.active_time is None
+        assert dev.inactive_time >= 0.1
+
+
+def test_basic_callbacks(mock_factory):
+    pin = mock_factory.pin(4)
+    evt = Event()
+    with DigitalInputDevice(4) as dev:
+        dev.when_activated = evt.set
+        assert dev.when_activated is not None
+        pin.drive_high()
+        assert evt.wait(0.1)
+        pin.drive_low()
+        dev.when_activated = None
+        assert dev.when_activated is None
+        evt.clear()
+        pin.drive_high()
+        assert not evt.wait(0.1)
+
+
+def test_builtin_callbacks(mock_factory):
+    pin = mock_factory.pin(4)
+    with DigitalInputDevice(4) as dev:
+        assert gc.isenabled()
+        dev.when_activated = gc.disable
+        assert dev.when_activated is gc.disable
+        pin.drive_high()
+        assert not gc.isenabled()
+        gc.enable()
+
+
+def test_callback_with_param(mock_factory):
+    pin = mock_factory.pin(4)
+    with DigitalInputDevice(4) as dev:
+        devices = []
+        evt = Event()
+        def cb(d):
+            devices.append(d)
+            evt.set()
+        dev.when_activated = cb
+        assert dev.when_activated is not None
+        pin.drive_high()
+        assert evt.wait(1)
+        assert devices == [dev]
+
+
+def test_bad_callback(mock_factory):
+    pin = mock_factory.pin(4)
+    with DigitalInputDevice(4) as dev:
+        with pytest.raises(BadEventHandler):
+            dev.when_activated = 100
+        with pytest.raises(BadEventHandler):
+            dev.when_activated = lambda x, y: x + y

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -15,19 +15,12 @@ from gpiozero.pins.mock import MockPWMPin, MockPin
 from gpiozero import *
 
 
-def teardown_function(function):
-    Device.pin_factory.reset()
-
-
-# Some rough tests to make sure our MockPin is up to snuff. This is just
-# enough to get reasonable coverage but it's by no means comprehensive...
-
-def test_mock_pin_init():
+def test_mock_pin_init(mock_factory):
     with pytest.raises(ValueError):
         Device.pin_factory.pin(60)
     assert Device.pin_factory.pin(2).number == 2
 
-def test_mock_pin_defaults():
+def test_mock_pin_defaults(mock_factory):
     pin = Device.pin_factory.pin(4)
     assert pin.bounce == None
     assert pin.edges == 'both'
@@ -40,23 +33,23 @@ def test_mock_pin_defaults():
     pin = Device.pin_factory.pin(2)
     assert pin.pull == 'up'
 
-def test_mock_pin_open_close():
+def test_mock_pin_open_close(mock_factory):
     pin = Device.pin_factory.pin(2)
     pin.close()
 
-def test_mock_pin_init_twice_same_pin():
+def test_mock_pin_init_twice_same_pin(mock_factory):
     pin1 = Device.pin_factory.pin(2)
     pin2 = Device.pin_factory.pin(pin1.number)
     assert pin1 is pin2
 
-def test_mock_pin_init_twice_different_pin():
+def test_mock_pin_init_twice_different_pin(mock_factory):
     pin1 = Device.pin_factory.pin(2)
     pin2 = Device.pin_factory.pin(pin1.number+1)
     assert pin1 != pin2
     assert pin1.number == 2
     assert pin2.number == pin1.number+1
 
-def test_mock_pwm_pin_defaults():
+def test_mock_pwm_pin_defaults(mock_factory):
     pin = Device.pin_factory.pin(4, pin_class=MockPWMPin)
     assert pin.bounce == None
     assert pin.edges == 'both'
@@ -69,23 +62,23 @@ def test_mock_pwm_pin_defaults():
     pin = Device.pin_factory.pin(2, pin_class=MockPWMPin)
     assert pin.pull == 'up'
 
-def test_mock_pwm_pin_open_close():
+def test_mock_pwm_pin_open_close(mock_factory):
     pin = Device.pin_factory.pin(2, pin_class=MockPWMPin)
     pin.close()
 
-def test_mock_pwm_pin_init_twice_same_pin():
+def test_mock_pwm_pin_init_twice_same_pin(mock_factory):
     pin1 = Device.pin_factory.pin(2, pin_class=MockPWMPin)
     pin2 = Device.pin_factory.pin(pin1.number, pin_class=MockPWMPin)
     assert pin1 is pin2
 
-def test_mock_pwm_pin_init_twice_different_pin():
+def test_mock_pwm_pin_init_twice_different_pin(mock_factory):
     pin1 = Device.pin_factory.pin(2, pin_class=MockPWMPin)
     pin2 = Device.pin_factory.pin(pin1.number + 1, pin_class=MockPWMPin)
     assert pin1 != pin2
     assert pin1.number == 2
     assert pin2.number == pin1.number+1
 
-def test_mock_pin_init_twice_different_modes():
+def test_mock_pin_init_twice_different_modes(mock_factory):
     pin1 = Device.pin_factory.pin(2, pin_class=MockPin)
     pin2 = Device.pin_factory.pin(pin1.number + 1, pin_class=MockPWMPin)
     assert pin1 != pin2
@@ -94,13 +87,13 @@ def test_mock_pin_init_twice_different_modes():
     with pytest.raises(ValueError):
         Device.pin_factory.pin(pin2.number, pin_class=MockPin)
 
-def test_mock_pin_frequency_unsupported():
+def test_mock_pin_frequency_unsupported(mock_factory):
     pin = Device.pin_factory.pin(2)
     pin.frequency = None
     with pytest.raises(PinPWMUnsupported):
         pin.frequency = 100
 
-def test_mock_pin_frequency_supported():
+def test_mock_pin_frequency_supported(mock_factory):
     pin = Device.pin_factory.pin(2, pin_class=MockPWMPin)
     pin.function = 'output'
     assert pin.frequency is None
@@ -109,7 +102,7 @@ def test_mock_pin_frequency_supported():
     pin.frequency = None
     assert not pin.state
 
-def test_mock_pin_pull():
+def test_mock_pin_pull(mock_factory):
     pin = Device.pin_factory.pin(4)
     pin.function = 'input'
     assert pin.pull == 'floating'
@@ -124,7 +117,7 @@ def test_mock_pin_pull():
     with pytest.raises(PinFixedPull):
         pin.pull = 'floating'
 
-def test_mock_pin_state():
+def test_mock_pin_state(mock_factory):
     pin = Device.pin_factory.pin(2)
     with pytest.raises(PinSetInput):
         pin.state = 1
@@ -136,7 +129,7 @@ def test_mock_pin_state():
     pin.state = 0.5
     assert pin.state == 1
 
-def test_mock_pwm_pin_state():
+def test_mock_pwm_pin_state(mock_factory):
     pin = Device.pin_factory.pin(2, pin_class=MockPWMPin)
     with pytest.raises(PinSetInput):
         pin.state = 1
@@ -148,7 +141,7 @@ def test_mock_pwm_pin_state():
     pin.state = 0.5
     assert pin.state == 0.5
 
-def test_mock_pin_edges():
+def test_mock_pin_edges(mock_factory):
     pin = Device.pin_factory.pin(2)
     assert pin.when_changed is None
     fired = Event()

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -17,76 +17,11 @@ except ImportError:
 import pytest
 from colorzero import Color, Red, Green, Blue
 
-from gpiozero.pins.mock import MockPin, MockPWMPin
 from gpiozero import *
 
 
-def setup_function(function):
-    # dirty, but it does the job
-    Device.pin_factory.pin_class = MockPWMPin if function.__name__ in (
-        'test_output_pwm_states',
-        'test_output_pwm_read',
-        'test_output_pwm_write',
-        'test_output_pwm_toggle',
-        'test_output_pwm_active_high_read',
-        'test_output_pwm_bad_value',
-        'test_output_pwm_write_closed',
-        'test_output_pwm_write_silly',
-        'test_output_pwm_blink_background',
-        'test_output_pwm_blink_foreground',
-        'test_output_pwm_fade_background',
-        'test_output_pwm_fade_foreground',
-        'test_output_pwm_pulse_background',
-        'test_output_pwm_pulse_foreground',
-        'test_output_pwm_blink_interrupt',
-        'test_rgbled_initial_value',
-        'test_rgbled_initial_bad_value',
-        'test_rgbled_value',
-        'test_rgbled_bad_value',
-        'test_rgbled_toggle',
-        'test_rgbled_bad_color_value_pwm',
-        'test_rgbled_color_value_pwm',
-        'test_rgbled_bad_rgb_property_pwm',
-        'test_rgbled_rgb_property_pwm',
-        'test_rgbled_color_name_pwm',
-        'test_rgbled_blink_background',
-        'test_rgbled_blink_foreground',
-        'test_rgbled_fade_background',
-        'test_rgbled_fade_foreground',
-        'test_rgbled_pulse_background',
-        'test_rgbled_pulse_foreground',
-        'test_rgbled_blink_interrupt',
-        'test_rgbled_close',
-        'test_motor_pins',
-        'test_motor_close',
-        'test_motor_value',
-        'test_motor_bad_value',
-        'test_motor_reverse',
-        'test_motor_enable_pin_bad_init',
-        'test_motor_enable_pin_init',
-        'test_motor_enable_pin',
-        'test_phaseenable_motor_pins',
-        'test_phaseenable_motor_close',
-        'test_phaseenable_motor_value',
-        'test_phaseenable_motor_bad_value',
-        'test_phaseenable_motor_reverse',
-        'test_servo_pins',
-        'test_servo_bad_value',
-        'test_servo_close',
-        'test_servo_pulse_width',
-        'test_servo_values',
-        'test_servo_initial_values',
-        'test_angular_servo_range',
-        'test_angular_servo_angles',
-        'test_angular_servo_initial_angles',
-        ) else MockPin
-
-def teardown_function(function):
-    Device.pin_factory.reset()
-
-
-def test_output_initial_values():
-    pin = Device.pin_factory.pin(2)
+def test_output_initial_values(mock_factory, pwm):
+    pin = mock_factory.pin(2)
     with OutputDevice(2, initial_value=False) as device:
         assert pin.function == 'output'
         assert not pin.state
@@ -96,23 +31,23 @@ def test_output_initial_values():
     with OutputDevice(2, initial_value=None) as device:
         assert state == pin.state
 
-def test_output_write_active_high():
-    pin = Device.pin_factory.pin(2)
+def test_output_write_active_high(mock_factory):
+    pin = mock_factory.pin(2)
     with OutputDevice(2) as device:
         device.on()
         assert pin.state
         device.off()
         assert not pin.state
 
-def test_output_write_active_low():
-    pin = Device.pin_factory.pin(2)
+def test_output_write_active_low(mock_factory):
+    pin = mock_factory.pin(2)
     with OutputDevice(2, active_high=False) as device:
         device.on()
         assert not pin.state
         device.off()
         assert pin.state
 
-def test_output_write_closed():
+def test_output_write_closed(mock_factory):
     with OutputDevice(2) as device:
         device.close()
         assert device.closed
@@ -121,15 +56,15 @@ def test_output_write_closed():
         with pytest.raises(GPIODeviceClosed):
             device.on()
 
-def test_output_write_silly():
-    pin = Device.pin_factory.pin(2)
+def test_output_write_silly(mock_factory):
+    pin = mock_factory.pin(2)
     with OutputDevice(2) as device:
         pin.function = 'input'
         with pytest.raises(AttributeError):
             device.on()
 
-def test_output_value():
-    pin = Device.pin_factory.pin(2)
+def test_output_value(mock_factory):
+    pin = mock_factory.pin(2)
     with OutputDevice(2) as device:
         assert not device.value
         assert not pin.state
@@ -140,8 +75,8 @@ def test_output_value():
         assert not device.value
         assert not pin.state
 
-def test_output_digital_toggle():
-    pin = Device.pin_factory.pin(2)
+def test_output_digital_toggle(mock_factory):
+    pin = mock_factory.pin(2)
     with DigitalOutputDevice(2) as device:
         assert not device.value
         assert not pin.state
@@ -154,8 +89,8 @@ def test_output_digital_toggle():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_output_blink_background():
-    pin = Device.pin_factory.pin(4)
+def test_output_blink_background(mock_factory):
+    pin = mock_factory.pin(4)
     with DigitalOutputDevice(4) as device:
         start = time()
         device.blink(0.1, 0.1, n=2)
@@ -172,8 +107,8 @@ def test_output_blink_background():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_output_blink_foreground():
-    pin = Device.pin_factory.pin(4)
+def test_output_blink_foreground(mock_factory):
+    pin = mock_factory.pin(4)
     with DigitalOutputDevice(4) as device:
         start = time()
         device.blink(0.1, 0.1, n=2, background=False)
@@ -186,40 +121,40 @@ def test_output_blink_foreground():
             (0.1, False)
             ])
 
-def test_output_blink_interrupt_on():
-    pin = Device.pin_factory.pin(4)
+def test_output_blink_interrupt_on(mock_factory):
+    pin = mock_factory.pin(4)
     with DigitalOutputDevice(4) as device:
         device.blink(1, 0.1)
         sleep(0.2)
         device.off() # should interrupt while on
         pin.assert_states([False, True, False])
 
-def test_output_blink_interrupt_off():
-    pin = Device.pin_factory.pin(4)
+def test_output_blink_interrupt_off(mock_factory):
+    pin = mock_factory.pin(4)
     with DigitalOutputDevice(4) as device:
         device.blink(0.1, 1)
         sleep(0.2)
         device.off() # should interrupt while off
         pin.assert_states([False, True, False])
 
-def test_output_pwm_bad_initial_value():
+def test_output_pwm_bad_initial_value(mock_factory):
     with pytest.raises(ValueError):
         PWMOutputDevice(2, initial_value=2)
 
-def test_output_pwm_not_supported():
+def test_output_pwm_not_supported(mock_factory):
     with pytest.raises(AttributeError):
         PWMOutputDevice(2)
 
-def test_output_pwm_states():
-    pin = Device.pin_factory.pin(4)
+def test_output_pwm_states(mock_factory, pwm):
+    pin = mock_factory.pin(4)
     with PWMOutputDevice(4) as device:
         device.value = 0.1
         device.value = 0.2
         device.value = 0.0
         pin.assert_states([0.0, 0.1, 0.2, 0.0])
 
-def test_output_pwm_read():
-    pin = Device.pin_factory.pin(2)
+def test_output_pwm_read(mock_factory, pwm):
+    pin = mock_factory.pin(2)
     with PWMOutputDevice(2, frequency=100) as device:
         assert device.frequency == 100
         device.value = 0.1
@@ -231,15 +166,15 @@ def test_output_pwm_read():
         assert not device.is_active
         assert device.frequency is None
 
-def test_output_pwm_write():
-    pin = Device.pin_factory.pin(4)
+def test_output_pwm_write(mock_factory, pwm):
+    pin = mock_factory.pin(4)
     with PWMOutputDevice(4) as device:
         device.on()
         device.off()
         pin.assert_states([False, True, False])
 
-def test_output_pwm_toggle():
-    pin = Device.pin_factory.pin(4)
+def test_output_pwm_toggle(mock_factory, pwm):
+    pin = mock_factory.pin(4)
     with PWMOutputDevice(4) as device:
         device.toggle()
         device.value = 0.5
@@ -248,8 +183,8 @@ def test_output_pwm_toggle():
         device.off()
         pin.assert_states([False, True, 0.5, 0.1, 0.9, False])
 
-def test_output_pwm_active_high_read():
-    pin = Device.pin_factory.pin(2)
+def test_output_pwm_active_high_read(mock_factory, pwm):
+    pin = mock_factory.pin(2)
     with PWMOutputDevice(2, active_high=False) as device:
         device.value = 0.1
         assert isclose(device.value, 0.1)
@@ -257,21 +192,21 @@ def test_output_pwm_active_high_read():
         device.frequency = None
         assert device.value
 
-def test_output_pwm_bad_value():
-    pin = Device.pin_factory.pin(2)
+def test_output_pwm_bad_value(mock_factory, pwm):
+    pin = mock_factory.pin(2)
     with PWMOutputDevice(2) as device:
         with pytest.raises(ValueError):
             device.value = 2
 
-def test_output_pwm_write_closed():
-    pin = Device.pin_factory.pin(2)
+def test_output_pwm_write_closed(mock_factory, pwm):
+    pin = mock_factory.pin(2)
     with PWMOutputDevice(2) as device:
         device.close()
         with pytest.raises(GPIODeviceClosed):
             device.on()
 
-def test_output_pwm_write_silly():
-    pin = Device.pin_factory.pin(2)
+def test_output_pwm_write_silly(mock_factory, pwm):
+    pin = mock_factory.pin(2)
     with PWMOutputDevice(2) as device:
         pin.function = 'input'
         with pytest.raises(AttributeError):
@@ -279,8 +214,8 @@ def test_output_pwm_write_silly():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_output_pwm_blink_background():
-    pin = Device.pin_factory.pin(4)
+def test_output_pwm_blink_background(mock_factory, pwm):
+    pin = mock_factory.pin(4)
     with PWMOutputDevice(4) as device:
         start = time()
         device.blink(0.1, 0.1, n=2)
@@ -297,8 +232,8 @@ def test_output_pwm_blink_background():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_output_pwm_blink_foreground():
-    pin = Device.pin_factory.pin(4)
+def test_output_pwm_blink_foreground(mock_factory, pwm):
+    pin = mock_factory.pin(4)
     with PWMOutputDevice(4) as device:
         start = time()
         device.blink(0.1, 0.1, n=2, background=False)
@@ -313,8 +248,8 @@ def test_output_pwm_blink_foreground():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_output_pwm_fade_background():
-    pin = Device.pin_factory.pin(4)
+def test_output_pwm_fade_background(mock_factory, pwm):
+    pin = mock_factory.pin(4)
     with PWMOutputDevice(4) as device:
         start = time()
         device.blink(0, 0, 0.2, 0.2, n=2)
@@ -347,8 +282,8 @@ def test_output_pwm_fade_background():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_output_pwm_fade_foreground():
-    pin = Device.pin_factory.pin(4)
+def test_output_pwm_fade_foreground(mock_factory, pwm):
+    pin = mock_factory.pin(4)
     with PWMOutputDevice(4) as device:
         start = time()
         device.blink(0, 0, 0.2, 0.2, n=2, background=False)
@@ -379,8 +314,8 @@ def test_output_pwm_fade_foreground():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_output_pwm_pulse_background():
-    pin = Device.pin_factory.pin(4)
+def test_output_pwm_pulse_background(mock_factory, pwm):
+    pin = mock_factory.pin(4)
     with PWMOutputDevice(4) as device:
         start = time()
         device.pulse(0.2, 0.2, n=2)
@@ -413,8 +348,8 @@ def test_output_pwm_pulse_background():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_output_pwm_pulse_foreground():
-    pin = Device.pin_factory.pin(4)
+def test_output_pwm_pulse_foreground(mock_factory, pwm):
+    pin = mock_factory.pin(4)
     with PWMOutputDevice(4) as device:
         start = time()
         device.pulse(0.2, 0.2, n=2, background=False)
@@ -443,20 +378,20 @@ def test_output_pwm_pulse_foreground():
             (0.04, 0),
             ])
 
-def test_output_pwm_blink_interrupt():
-    pin = Device.pin_factory.pin(4)
+def test_output_pwm_blink_interrupt(mock_factory, pwm):
+    pin = mock_factory.pin(4)
     with PWMOutputDevice(4) as device:
         device.blink(1, 0.1)
         sleep(0.2)
         device.off() # should interrupt while on
         pin.assert_states([0, 1, 0])
 
-def test_rgbled_missing_pins():
+def test_rgbled_missing_pins(mock_factory):
     with pytest.raises(GPIOPinMissing):
         RGBLED()
 
-def test_rgbled_initial_value():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
+def test_rgbled_initial_value(mock_factory, pwm):
+    r, g, b = (mock_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3, initial_value=(0.1, 0.2, 0)) as led:
         assert r.frequency
         assert g.frequency
@@ -465,22 +400,22 @@ def test_rgbled_initial_value():
         assert isclose(g.state, 0.2)
         assert isclose(b.state, 0.0)
 
-def test_rgbled_initial_value_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
+def test_rgbled_initial_value_nonpwm(mock_factory):
+    r, g, b = (mock_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3, pwm=False, initial_value=(0, 1, 1)) as led:
         assert r.state == 0
         assert g.state == 1
         assert b.state == 1
 
-def test_rgbled_initial_bad_value():
+def test_rgbled_initial_bad_value(mock_factory, pwm):
     with pytest.raises(ValueError):
         RGBLED(1, 2, 3, initial_value=(0.1, 0.2, 1.2))
 
-def test_rgbled_initial_bad_value_nonpwm():
+def test_rgbled_initial_bad_value_nonpwm(mock_factory):
     with pytest.raises(ValueError):
         RGBLED(1, 2, 3, pwm=False, initial_value=(0.1, 0.2, 0))
 
-def test_rgbled_value():
+def test_rgbled_value(mock_factory, pwm):
     with RGBLED(1, 2, 3) as led:
         assert isinstance(led._leds[0], PWMLED)
         assert isinstance(led._leds[1], PWMLED)
@@ -497,7 +432,7 @@ def test_rgbled_value():
         assert led.is_active
         assert led.value == (0.5, 0.5, 0.5)
 
-def test_rgbled_value_nonpwm():
+def test_rgbled_value_nonpwm(mock_factory):
     with RGBLED(1, 2, 3, pwm=False) as led:
         assert isinstance(led._leds[0], LED)
         assert isinstance(led._leds[1], LED)
@@ -511,7 +446,7 @@ def test_rgbled_value_nonpwm():
         assert not led.is_active
         assert led.value == (0, 0, 0)
 
-def test_rgbled_bad_value():
+def test_rgbled_bad_value(mock_factory, pwm):
     with RGBLED(1, 2, 3) as led:
         with pytest.raises(ValueError):
             led.value = (2, 0, 0)
@@ -519,7 +454,7 @@ def test_rgbled_bad_value():
         with pytest.raises(ValueError):
             led.value = (0, -1, 0)
 
-def test_rgbled_bad_value_nonpwm():
+def test_rgbled_bad_value_nonpwm(mock_factory):
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.value = (2, 0, 0)
@@ -536,7 +471,7 @@ def test_rgbled_bad_value_nonpwm():
         with pytest.raises(ValueError):
             led.value = (0, 0, 0.5)
 
-def test_rgbled_toggle():
+def test_rgbled_toggle(mock_factory, pwm):
     with RGBLED(1, 2, 3) as led:
         assert not led.is_active
         assert led.value == (0, 0, 0)
@@ -547,7 +482,7 @@ def test_rgbled_toggle():
         assert not led.is_active
         assert led.value == (0, 0, 0)
 
-def test_rgbled_toggle_nonpwm():
+def test_rgbled_toggle_nonpwm(mock_factory):
     with RGBLED(1, 2, 3, pwm=False) as led:
         assert not led.is_active
         assert led.value == (0, 0, 0)
@@ -558,7 +493,7 @@ def test_rgbled_toggle_nonpwm():
         assert not led.is_active
         assert led.value == (0, 0, 0)
 
-def test_rgbled_bad_color_value_nopwm():
+def test_rgbled_bad_color_value_nonpwm(mock_factory):
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.color = (0.5, 0, 0)
@@ -567,7 +502,7 @@ def test_rgbled_bad_color_value_nopwm():
         with pytest.raises(ValueError):
             led.color = (0, 0, -1)
 
-def test_rgbled_bad_color_value_pwm():
+def test_rgbled_bad_color_value_pwm(mock_factory, pwm):
     with RGBLED(1, 2, 3) as led:
         with pytest.raises(ValueError):
             led.color = (0, 1.5, 0)
@@ -578,7 +513,7 @@ def test_rgbled_bad_color_value_pwm():
         with pytest.raises(ValueError):
             led.blue = -1
 
-def test_rgbled_color_value_nopwm():
+def test_rgbled_color_value_nonpwm(mock_factory):
     with RGBLED(1, 2, 3, pwm=False) as led:
         assert led.value == (0, 0, 0)
         assert led.red == 0
@@ -602,7 +537,7 @@ def test_rgbled_color_value_nopwm():
         led.blue = 1
         assert led.value == (1, 0, 1)
 
-def test_rgbled_color_value_pwm():
+def test_rgbled_color_value_pwm(mock_factory, pwm):
     with RGBLED(1, 2, 3) as led:
         assert led.value == (0, 0, 0)
         assert led.red == 0
@@ -626,7 +561,7 @@ def test_rgbled_color_value_pwm():
         led.blue = 0.4
         assert led.value == (0.5, 0.9, 0.4)
 
-def test_rgbled_bad_rgb_property_nopwm():
+def test_rgbled_bad_rgb_property_nonpwm(mock_factory):
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.red = 0.1
@@ -641,7 +576,7 @@ def test_rgbled_bad_rgb_property_nopwm():
         with pytest.raises(ValueError):
             led.blue = Blue(0.9)
 
-def test_rgbled_bad_rgb_property_pwm():
+def test_rgbled_bad_rgb_property_pwm(mock_factory, pwm):
     with RGBLED(1, 2, 3) as led:
         with pytest.raises(ValueError):
             led.red = 1.5
@@ -656,7 +591,7 @@ def test_rgbled_bad_rgb_property_pwm():
         with pytest.raises(ValueError):
             led.blue = Blue(-1)
 
-def test_rgbled_rgb_property_nopwm():
+def test_rgbled_rgb_property_nonpwm(mock_factory):
     with RGBLED(1, 2, 3, pwm=False) as led:
         assert led.value == (0, 0, 0)
         led.red = Red(0)
@@ -668,7 +603,7 @@ def test_rgbled_rgb_property_nopwm():
         led.blue = Blue(1)
         assert led.value == (1, 1, 1)
 
-def test_rgbled_rgb_property_pwm():
+def test_rgbled_rgb_property_pwm(mock_factory, pwm):
     with RGBLED(1, 2, 3) as led:
         assert led.value == (0, 0, 0)
         led.red = Red(0)
@@ -680,7 +615,7 @@ def test_rgbled_rgb_property_pwm():
         led.blue = Blue(0.5)
         assert led.value == (0.5, 0.5, 0.5)
 
-def test_rgbled_bad_color_name_nopwm():
+def test_rgbled_bad_color_name_nonpwm(mock_factory):
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.color = Color('green')  # html 'green' is (0, ~0.5, 0)
@@ -689,7 +624,7 @@ def test_rgbled_bad_color_name_nopwm():
         with pytest.raises(ValueError):
             led.color = Color(250, 0, 0)
 
-def test_rgbled_color_name_nopwm():
+def test_rgbled_color_name_nonpwm(mock_factory):
     with RGBLED(1, 2, 3, pwm=False) as led:
         assert led.value == (0, 0, 0)
         led.color = Color('white')
@@ -709,7 +644,7 @@ def test_rgbled_color_name_nopwm():
         led.color = Color('yellow')
         assert led.value == (1, 1, 0)
 
-def test_rgbled_color_name_pwm():
+def test_rgbled_color_name_pwm(mock_factory, pwm):
     with RGBLED(1, 2, 3) as led:
         assert led.value == (0, 0, 0)
         led.color = Color('white')
@@ -721,7 +656,7 @@ def test_rgbled_color_name_pwm():
         led.color = Color('purple')
         assert led.value == (0.5019607843137255, 0.0, 0.5019607843137255)
 
-def test_rgbled_blink_nonpwm():
+def test_rgbled_blink_nonpwm(mock_factory):
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.blink(fade_in_time=1)
@@ -730,8 +665,8 @@ def test_rgbled_blink_nonpwm():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_rgbled_blink_background():
-    r, g, b = (Device.pin_factory.pin(i) for i in (4, 5, 6))
+def test_rgbled_blink_background(mock_factory, pwm):
+    r, g, b = (mock_factory.pin(i) for i in (4, 5, 6))
     with RGBLED(1, 2, 3) as led:
         start = time()
         led.blink(0.1, 0.1, n=2)
@@ -751,8 +686,8 @@ def test_rgbled_blink_background():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_rgbled_blink_background_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (4, 5, 6))
+def test_rgbled_blink_background_nonpwm(mock_factory):
+    r, g, b = (mock_factory.pin(i) for i in (4, 5, 6))
     with RGBLED(1, 2, 3, pwm=False) as led:
         start = time()
         led.blink(0.1, 0.1, n=2)
@@ -772,8 +707,8 @@ def test_rgbled_blink_background_nonpwm():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_rgbled_blink_foreground():
-    r, g, b = (Device.pin_factory.pin(i) for i in (4, 5, 6))
+def test_rgbled_blink_foreground(mock_factory, pwm):
+    r, g, b = (mock_factory.pin(i) for i in (4, 5, 6))
     with RGBLED(1, 2, 3) as led:
         start = time()
         led.blink(0.1, 0.1, n=2, background=False)
@@ -791,8 +726,8 @@ def test_rgbled_blink_foreground():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_rgbled_blink_foreground_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (4, 5, 6))
+def test_rgbled_blink_foreground_nonpwm(mock_factory):
+    r, g, b = (mock_factory.pin(i) for i in (4, 5, 6))
     with RGBLED(1, 2, 3, pwm=False) as led:
         start = time()
         led.blink(0.1, 0.1, n=2, background=False)
@@ -810,8 +745,8 @@ def test_rgbled_blink_foreground_nonpwm():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_rgbled_fade_background():
-    r, g, b = (Device.pin_factory.pin(i) for i in (4, 5, 6))
+def test_rgbled_fade_background(mock_factory, pwm):
+    r, g, b = (mock_factory.pin(i) for i in (4, 5, 6))
     with RGBLED(1, 2, 3) as led:
         start = time()
         led.blink(0, 0, 0.2, 0.2, n=2)
@@ -845,8 +780,8 @@ def test_rgbled_fade_background():
         g.assert_states_and_times(expected)
         b.assert_states_and_times(expected)
 
-def test_rgbled_fade_background_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
+def test_rgbled_fade_background_nonpwm(mock_factory):
+    r, g, b = (mock_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.blink(0, 0, 0.2, 0, n=2)
@@ -855,8 +790,8 @@ def test_rgbled_fade_background_nonpwm():
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_rgbled_fade_foreground():
-    r, g, b = (Device.pin_factory.pin(i) for i in (4, 5, 6))
+def test_rgbled_fade_foreground(mock_factory, pwm):
+    r, g, b = (mock_factory.pin(i) for i in (4, 5, 6))
     with RGBLED(1, 2, 3) as led:
         start = time()
         led.blink(0, 0, 0.2, 0.2, n=2, background=False)
@@ -888,16 +823,16 @@ def test_rgbled_fade_foreground():
         g.assert_states_and_times(expected)
         b.assert_states_and_times(expected)
 
-def test_rgbled_fade_foreground_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
+def test_rgbled_fade_foreground_nonpwm(mock_factory):
+    r, g, b = (mock_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.blink(0, 0, 0.2, 0.2, n=2, background=False)
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_rgbled_pulse_background():
-    r, g, b = (Device.pin_factory.pin(i) for i in (4, 5, 6))
+def test_rgbled_pulse_background(mock_factory, pwm):
+    r, g, b = (mock_factory.pin(i) for i in (4, 5, 6))
     with RGBLED(1, 2, 3) as led:
         start = time()
         led.pulse(0.2, 0.2, n=2)
@@ -931,16 +866,16 @@ def test_rgbled_pulse_background():
         g.assert_states_and_times(expected)
         b.assert_states_and_times(expected)
 
-def test_rgbled_pulse_background_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
+def test_rgbled_pulse_background_nonpwm(mock_factory):
+    r, g, b = (mock_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.pulse(0.2, 0.2, n=2)
 
 @pytest.mark.skipif(hasattr(sys, 'pypy_version_info'),
                     reason='timing is too random on pypy')
-def test_rgbled_pulse_foreground():
-    r, g, b = (Device.pin_factory.pin(i) for i in (4, 5, 6))
+def test_rgbled_pulse_foreground(mock_factory, pwm):
+    r, g, b = (mock_factory.pin(i) for i in (4, 5, 6))
     with RGBLED(1, 2, 3) as led:
         start = time()
         led.pulse(0.2, 0.2, n=2, background=False)
@@ -972,14 +907,14 @@ def test_rgbled_pulse_foreground():
         g.assert_states_and_times(expected)
         b.assert_states_and_times(expected)
 
-def test_rgbled_pulse_foreground_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
+def test_rgbled_pulse_foreground_nonpwm(mock_factory):
+    r, g, b = (mock_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3, pwm=False) as led:
         with pytest.raises(ValueError):
             led.pulse(0.2, 0.2, n=2, background=False)
 
-def test_rgbled_blink_interrupt():
-    r, g, b = (Device.pin_factory.pin(i) for i in (4, 5, 6))
+def test_rgbled_blink_interrupt(mock_factory, pwm):
+    r, g, b = (mock_factory.pin(i) for i in (4, 5, 6))
     with RGBLED(1, 2, 3) as led:
         led.blink(1, 0.1)
         sleep(0.2)
@@ -988,8 +923,8 @@ def test_rgbled_blink_interrupt():
         g.assert_states([0, 1, 0])
         b.assert_states([0, 1, 0])
 
-def test_rgbled_blink_interrupt_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (4, 5, 6))
+def test_rgbled_blink_interrupt_nonpwm(mock_factory):
+    r, g, b = (mock_factory.pin(i) for i in (4, 5, 6))
     with RGBLED(1, 2, 3, pwm=False) as led:
         led.blink(1, 0.1)
         sleep(0.2)
@@ -998,8 +933,8 @@ def test_rgbled_blink_interrupt_nonpwm():
         g.assert_states([0, 1, 0])
         b.assert_states([0, 1, 0])
 
-def test_rgbled_close():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
+def test_rgbled_close(mock_factory, pwm):
+    r, g, b = (mock_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3) as led:
         assert not led.closed
         led.close()
@@ -1007,8 +942,8 @@ def test_rgbled_close():
         led.close()
         assert led.closed
 
-def test_rgbled_close_nonpwm():
-    r, g, b = (Device.pin_factory.pin(i) for i in (1, 2, 3))
+def test_rgbled_close_nonpwm(mock_factory):
+    r, g, b = (mock_factory.pin(i) for i in (1, 2, 3))
     with RGBLED(1, 2, 3, pwm=False) as led:
         assert not led.closed
         led.close()
@@ -1016,7 +951,7 @@ def test_rgbled_close_nonpwm():
         led.close()
         assert led.closed
 
-def test_motor_bad_init():
+def test_motor_bad_init(mock_factory):
     with pytest.raises(GPIOPinMissing):
         Motor()
     with pytest.raises(GPIOPinMissing):
@@ -1028,27 +963,27 @@ def test_motor_bad_init():
     with pytest.raises(TypeError):
         Motor(a=2, b=3)
 
-def test_motor_pins():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
+def test_motor_pins(mock_factory, pwm):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
     with Motor(1, 2) as motor:
         assert motor.forward_device.pin is f
         assert isinstance(motor.forward_device, PWMOutputDevice)
         assert motor.backward_device.pin is b
         assert isinstance(motor.backward_device, PWMOutputDevice)
 
-def test_motor_pins_nonpwm():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
+def test_motor_pins_nonpwm(mock_factory):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
     with Motor(1, 2, pwm=False) as motor:
         assert motor.forward_device.pin is f
         assert isinstance(motor.forward_device, DigitalOutputDevice)
         assert motor.backward_device.pin is b
         assert isinstance(motor.backward_device, DigitalOutputDevice)
 
-def test_motor_close():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
+def test_motor_close(mock_factory, pwm):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
     with Motor(1, 2) as motor:
         motor.close()
         assert motor.closed
@@ -1057,18 +992,18 @@ def test_motor_close():
         motor.close()
         assert motor.closed
 
-def test_motor_close_nonpwm():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
+def test_motor_close_nonpwm(mock_factory):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
     with Motor(1, 2, pwm=False) as motor:
         motor.close()
         assert motor.closed
         assert motor.forward_device.pin is None
         assert motor.backward_device.pin is None
 
-def test_motor_value():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
+def test_motor_value(mock_factory, pwm):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
     with Motor(1, 2) as motor:
         motor.value = -1
         assert motor.is_active
@@ -1091,9 +1026,9 @@ def test_motor_value():
         assert not motor.value
         assert b.state == 0 and f.state == 0
 
-def test_motor_value_nonpwm():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
+def test_motor_value_nonpwm(mock_factory):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
     with Motor(1, 2, pwm=False) as motor:
         motor.value = -1
         assert motor.is_active
@@ -1108,9 +1043,9 @@ def test_motor_value_nonpwm():
         assert not motor.value
         assert b.state == 0 and f.state == 0
 
-def test_motor_bad_value():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
+def test_motor_bad_value(mock_factory, pwm):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
     with Motor(1, 2) as motor:
         with pytest.raises(ValueError):
             motor.value = -2
@@ -1125,9 +1060,9 @@ def test_motor_bad_value():
         with pytest.raises(ValueError):
             motor.backward(-1)
 
-def test_motor_bad_value_nonpwm():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
+def test_motor_bad_value_nonpwm(mock_factory):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
     with Motor(1, 2, pwm=False) as motor:
         with pytest.raises(ValueError):
             motor.value = -2
@@ -1142,9 +1077,9 @@ def test_motor_bad_value_nonpwm():
         with pytest.raises(ValueError):
             motor.backward(0.5)
 
-def test_motor_reverse():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
+def test_motor_reverse(mock_factory, pwm):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
     with Motor(1, 2) as motor:
         motor.forward()
         assert motor.value == 1
@@ -1159,9 +1094,9 @@ def test_motor_reverse():
         assert motor.value == 0.5
         assert b.state == 0 and f.state == 0.5
 
-def test_motor_reverse_nonpwm():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
+def test_motor_reverse_nonpwm(mock_factory):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
     with Motor(1, 2, pwm=False) as motor:
         motor.forward()
         assert motor.value == 1
@@ -1170,7 +1105,7 @@ def test_motor_reverse_nonpwm():
         assert motor.value == -1
         assert b.state == 1 and f.state == 0
 
-def test_motor_enable_pin_bad_init():
+def test_motor_enable_pin_bad_init(mock_factory, pwm):
     with pytest.raises(GPIOPinMissing):
         Motor(enable=1)
     with pytest.raises(GPIOPinMissing):
@@ -1180,10 +1115,10 @@ def test_motor_enable_pin_bad_init():
     with pytest.raises(GPIOPinMissing):
         Motor(backward=1, enable=2, pwm=True)
 
-def test_motor_enable_pin_init():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
-    e = Device.pin_factory.pin(3)
+def test_motor_enable_pin_init(mock_factory, pwm):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
+    e = mock_factory.pin(3)
     with Motor(forward=1, backward=2, enable=3) as motor:
         assert motor.forward_device.pin is f
         assert isinstance(motor.forward_device, PWMOutputDevice)
@@ -1201,10 +1136,10 @@ def test_motor_enable_pin_init():
         assert isinstance(motor.enable_device, DigitalOutputDevice)
         assert e.state
 
-def test_motor_enable_pin_nopwm_init():
-    f = Device.pin_factory.pin(1)
-    b = Device.pin_factory.pin(2)
-    e = Device.pin_factory.pin(3)
+def test_motor_enable_pin_nonpwm_init(mock_factory):
+    f = mock_factory.pin(1)
+    b = mock_factory.pin(2)
+    e = mock_factory.pin(3)
     with Motor(forward=1, backward=2, enable=3, pwm=False) as motor:
         assert motor.forward_device.pin is f
         assert isinstance(motor.forward_device, DigitalOutputDevice)
@@ -1213,7 +1148,7 @@ def test_motor_enable_pin_nopwm_init():
         assert motor.enable_device.pin is e
         assert isinstance(motor.enable_device, DigitalOutputDevice)
 
-def test_motor_enable_pin():
+def test_motor_enable_pin(mock_factory, pwm):
     with Motor(forward=1, backward=2, enable=3) as motor:
         motor.forward()
         assert motor.value == 1
@@ -1222,27 +1157,27 @@ def test_motor_enable_pin():
         motor.stop()
         assert motor.value == 0
 
-def test_phaseenable_motor_pins():
-    p = Device.pin_factory.pin(1)
-    e = Device.pin_factory.pin(2)
+def test_phaseenable_motor_pins(mock_factory, pwm):
+    p = mock_factory.pin(1)
+    e = mock_factory.pin(2)
     with PhaseEnableMotor(1, 2) as motor:
         assert motor.phase_device.pin is p
         assert isinstance(motor.phase_device, OutputDevice)
         assert motor.enable_device.pin is e
         assert isinstance(motor.enable_device, PWMOutputDevice)
 
-def test_phaseenable_motor_pins_nonpwm():
-    p = Device.pin_factory.pin(1)
-    e = Device.pin_factory.pin(2)
+def test_phaseenable_motor_pins_nonpwm(mock_factory):
+    p = mock_factory.pin(1)
+    e = mock_factory.pin(2)
     with PhaseEnableMotor(1, 2, pwm=False) as motor:
         assert motor.phase_device.pin is p
         assert isinstance(motor.phase_device, OutputDevice)
         assert motor.enable_device.pin is e
         assert isinstance(motor.enable_device, DigitalOutputDevice)
 
-def test_phaseenable_motor_close():
-    p = Device.pin_factory.pin(1)
-    e = Device.pin_factory.pin(2)
+def test_phaseenable_motor_close(mock_factory, pwm):
+    p = mock_factory.pin(1)
+    e = mock_factory.pin(2)
     with PhaseEnableMotor(1, 2) as motor:
         motor.close()
         assert motor.closed
@@ -1251,18 +1186,18 @@ def test_phaseenable_motor_close():
         motor.close()
         assert motor.closed
 
-def test_phaseenable_motor_close_nonpwm():
-    p = Device.pin_factory.pin(1)
-    e = Device.pin_factory.pin(2)
+def test_phaseenable_motor_close_nonpwm(mock_factory):
+    p = mock_factory.pin(1)
+    e = mock_factory.pin(2)
     with PhaseEnableMotor(1, 2, pwm=False) as motor:
         motor.close()
         assert motor.closed
         assert motor.phase_device.pin is None
         assert motor.enable_device.pin is None
 
-def test_phaseenable_motor_value():
-    p = Device.pin_factory.pin(1)
-    e = Device.pin_factory.pin(2)
+def test_phaseenable_motor_value(mock_factory, pwm):
+    p = mock_factory.pin(1)
+    e = mock_factory.pin(2)
     with PhaseEnableMotor(1, 2) as motor:
         motor.value = -1
         assert motor.is_active
@@ -1285,9 +1220,9 @@ def test_phaseenable_motor_value():
         assert not motor.value
         assert e.state == 0
 
-def test_phaseenable_motor_value_nonpwm():
-    p = Device.pin_factory.pin(1)
-    e = Device.pin_factory.pin(2)
+def test_phaseenable_motor_value_nonpwm(mock_factory):
+    p = mock_factory.pin(1)
+    e = mock_factory.pin(2)
     with PhaseEnableMotor(1, 2, pwm=False) as motor:
         motor.value = -1
         assert motor.is_active
@@ -1302,9 +1237,9 @@ def test_phaseenable_motor_value_nonpwm():
         assert not motor.value
         assert e.state == 0
 
-def test_phaseenable_motor_bad_value():
-    p = Device.pin_factory.pin(1)
-    e = Device.pin_factory.pin(2)
+def test_phaseenable_motor_bad_value(mock_factory, pwm):
+    p = mock_factory.pin(1)
+    e = mock_factory.pin(2)
     with PhaseEnableMotor(1, 2) as motor:
         with pytest.raises(ValueError):
             motor.value = -2
@@ -1315,9 +1250,9 @@ def test_phaseenable_motor_bad_value():
         with pytest.raises(ValueError):
             motor.backward(2)
 
-def test_phaseenable_motor_bad_value_nonpwm():
-    p = Device.pin_factory.pin(1)
-    e = Device.pin_factory.pin(2)
+def test_phaseenable_motor_bad_value_nonpwm(mock_factory):
+    p = mock_factory.pin(1)
+    e = mock_factory.pin(2)
     with PhaseEnableMotor(1, 2, pwm=False) as motor:
         with pytest.raises(ValueError):
             motor.value = -2
@@ -1328,9 +1263,9 @@ def test_phaseenable_motor_bad_value_nonpwm():
         with pytest.raises(ValueError):
             motor.value = -0.5
 
-def test_phaseenable_motor_reverse():
-    p = Device.pin_factory.pin(1)
-    e = Device.pin_factory.pin(2)
+def test_phaseenable_motor_reverse(mock_factory, pwm):
+    p = mock_factory.pin(1)
+    e = mock_factory.pin(2)
     with PhaseEnableMotor(1, 2) as motor:
         motor.forward()
         assert motor.value == 1
@@ -1345,9 +1280,9 @@ def test_phaseenable_motor_reverse():
         assert motor.value == 0.5
         assert p.state == 0 and e.state == 0.5
 
-def test_phaseenable_motor_reverse_nonpwm():
-    p = Device.pin_factory.pin(1)
-    e = Device.pin_factory.pin(2)
+def test_phaseenable_motor_reverse_nonpwm(mock_factory):
+    p = mock_factory.pin(1)
+    e = mock_factory.pin(2)
     with PhaseEnableMotor(1, 2, pwm=False) as motor:
         motor.forward()
         assert motor.value == 1
@@ -1356,14 +1291,14 @@ def test_phaseenable_motor_reverse_nonpwm():
         assert motor.value == -1
         assert p.state == 1 and e.state == 1
 
-def test_servo_pins():
-    p = Device.pin_factory.pin(1)
+def test_servo_pins(mock_factory, pwm):
+    p = mock_factory.pin(1)
     with Servo(1) as servo:
         assert servo.pwm_device.pin is p
         assert isinstance(servo.pwm_device, PWMOutputDevice)
 
-def test_servo_bad_value():
-    p = Device.pin_factory.pin(1)
+def test_servo_bad_value(mock_factory, pwm):
+    p = mock_factory.pin(1)
     with pytest.raises(ValueError):
         Servo(1, initial_value=2)
     with pytest.raises(ValueError):
@@ -1371,13 +1306,13 @@ def test_servo_bad_value():
     with pytest.raises(ValueError):
         Servo(1, max_pulse_width=30/1000)
 
-def test_servo_pins_nonpwm():
-    p = Device.pin_factory.pin(2)
+def test_servo_pins_nonpwm(mock_factory):
+    p = mock_factory.pin(2)
     with pytest.raises(PinPWMUnsupported):
         Servo(1)
 
-def test_servo_close():
-    p = Device.pin_factory.pin(2)
+def test_servo_close(mock_factory, pwm):
+    p = mock_factory.pin(2)
     with Servo(2) as servo:
         servo.close()
         assert servo.closed
@@ -1385,8 +1320,8 @@ def test_servo_close():
         servo.close()
         assert servo.closed
 
-def test_servo_pulse_width():
-    p = Device.pin_factory.pin(2)
+def test_servo_pulse_width(mock_factory, pwm):
+    p = mock_factory.pin(2)
     with Servo(2, min_pulse_width=5/10000, max_pulse_width=25/10000) as servo:
         assert isclose(servo.min_pulse_width, 5/10000)
         assert isclose(servo.max_pulse_width, 25/10000)
@@ -1399,8 +1334,8 @@ def test_servo_pulse_width():
         servo.value = None
         assert servo.pulse_width is None
 
-def test_servo_initial_values():
-    p = Device.pin_factory.pin(2)
+def test_servo_initial_values(mock_factory, pwm):
+    p = mock_factory.pin(2)
     with Servo(2) as servo:
         assert servo.value == 0
     with Servo(2, initial_value=-1) as servo:
@@ -1419,8 +1354,8 @@ def test_servo_initial_values():
         assert not servo.is_active
         assert servo.value is None
 
-def test_servo_values():
-    p = Device.pin_factory.pin(1)
+def test_servo_values(mock_factory, pwm):
+    p = mock_factory.pin(1)
     with Servo(1) as servo:
         servo.min()
         assert servo.is_active
@@ -1446,14 +1381,14 @@ def test_servo_values():
         servo.value = None
         assert servo.value is None
 
-def test_angular_servo_range():
-    p = Device.pin_factory.pin(1)
+def test_angular_servo_range(mock_factory, pwm):
+    p = mock_factory.pin(1)
     with AngularServo(1, initial_angle=15, min_angle=0, max_angle=90) as servo:
         assert servo.min_angle == 0
         assert servo.max_angle == 90
 
-def test_angular_servo_initial_angles():
-    p = Device.pin_factory.pin(1)
+def test_angular_servo_initial_angles(mock_factory, pwm):
+    p = mock_factory.pin(1)
     with AngularServo(1) as servo:
         assert servo.angle == 0
     with AngularServo(1, initial_angle=-90) as servo:
@@ -1468,8 +1403,8 @@ def test_angular_servo_initial_angles():
     with AngularServo(1, initial_angle=None) as servo:
         assert servo.angle is None
 
-def test_angular_servo_angles():
-    p = Device.pin_factory.pin(1)
+def test_angular_servo_angles(mock_factory, pwm):
+    p = mock_factory.pin(1)
     with AngularServo(1) as servo:
         servo.angle = 0
         assert servo.angle == 0

--- a/tests/test_real_pins.py
+++ b/tests/test_real_pins.py
@@ -193,10 +193,3 @@ def test_explicit_factory(no_default_factory, pin_factory):
         assert Device.pin_factory is None
         assert device.pin_factory is pin_factory
         assert device.pin.number == TEST_PIN
-
-def test_default_factory(no_default_factory, pin_factory_name):
-    os.environ['GPIOZERO_PIN_FACTORY'] = pin_factory_name
-    with GPIODevice(TEST_PIN) as device:
-        assert Device.pin_factory is not None
-        assert Device.pin_factory is device.pin_factory
-        assert device.pin.number == TEST_PIN

--- a/tests/test_spi_devices.py
+++ b/tests/test_spi_devices.py
@@ -20,9 +20,6 @@ from gpiozero.pins.mock import MockSPIDevice, MockPin
 from gpiozero import *
 
 
-def teardown_function(function):
-    Device.pin_factory.reset()
-
 def clamp(v, min_value, max_value):
     return min(max_value, max(min_value, v))
 
@@ -259,7 +256,7 @@ def differential_mcp_test(mock, pot, pos_channel, neg_channel, bits, full=False)
         assert isclose(pot.voltage, 0.0, abs_tol=voltage_tolerance)
 
 
-def test_MCP3001():
+def test_MCP3001(mock_factory):
     with patch('gpiozero.pins.local.SpiDev', None):
         mock = MockMCP3001(11, 10, 9, 8)
         with MCP3001() as pot:
@@ -267,7 +264,7 @@ def test_MCP3001():
         with MCP3001(max_voltage=5.0) as pot:
             differential_mcp_test(mock, pot, 0, 1, 10)
 
-def test_MCP3002():
+def test_MCP3002(mock_factory):
     with patch('gpiozero.pins.local.SpiDev', None):
         mock = MockMCP3002(11, 10, 9, 8)
         with pytest.raises(ValueError):
@@ -279,7 +276,7 @@ def test_MCP3002():
         with MCP3002(channel=1, differential=True) as pot:
             differential_mcp_test(mock, pot, 1, 0, 10)
 
-def test_MCP3004():
+def test_MCP3004(mock_factory):
     with patch('gpiozero.pins.local.SpiDev', None):
         mock = MockMCP3004(11, 10, 9, 8)
         with pytest.raises(ValueError):
@@ -291,7 +288,7 @@ def test_MCP3004():
         with MCP3004(channel=3, differential=True) as pot:
             differential_mcp_test(mock, pot, 3, 2, 10)
 
-def test_MCP3008():
+def test_MCP3008(mock_factory):
     with patch('gpiozero.pins.local.SpiDev', None):
         mock = MockMCP3008(11, 10, 9, 8)
         with pytest.raises(ValueError):
@@ -303,7 +300,7 @@ def test_MCP3008():
         with MCP3008(channel=0, differential=True) as pot:
             differential_mcp_test(mock, pot, 0, 1, 10)
 
-def test_MCP3201():
+def test_MCP3201(mock_factory):
     with patch('gpiozero.pins.local.SpiDev', None):
         mock = MockMCP3201(11, 10, 9, 8)
         with MCP3201() as pot:
@@ -311,7 +308,7 @@ def test_MCP3201():
         with MCP3201(max_voltage=5.0) as pot:
             differential_mcp_test(mock, pot, 0, 1, 12)
 
-def test_MCP3202():
+def test_MCP3202(mock_factory):
     with patch('gpiozero.pins.local.SpiDev', None):
         mock = MockMCP3202(11, 10, 9, 8)
         with pytest.raises(ValueError):
@@ -323,7 +320,7 @@ def test_MCP3202():
         with MCP3202(channel=1, differential=True) as pot:
             differential_mcp_test(mock, pot, 1, 0, 12)
 
-def test_MCP3204():
+def test_MCP3204(mock_factory):
     with patch('gpiozero.pins.local.SpiDev', None):
         mock = MockMCP3204(11, 10, 9, 8)
         with pytest.raises(ValueError):
@@ -335,7 +332,7 @@ def test_MCP3204():
         with MCP3204(channel=1, differential=True) as pot:
             differential_mcp_test(mock, pot, 1, 0, 12)
 
-def test_MCP3208():
+def test_MCP3208(mock_factory):
     with patch('gpiozero.pins.local.SpiDev', None):
         mock = MockMCP3208(11, 10, 9, 8)
         with pytest.raises(ValueError):
@@ -347,7 +344,7 @@ def test_MCP3208():
         with MCP3208(channel=7, differential=True) as pot:
             differential_mcp_test(mock, pot, 7, 6, 12)
 
-def test_MCP3301():
+def test_MCP3301(mock_factory):
     with patch('gpiozero.pins.local.SpiDev', None):
         mock = MockMCP3301(11, 10, 9, 8)
         with MCP3301() as pot:
@@ -355,7 +352,7 @@ def test_MCP3301():
         with MCP3301(max_voltage=5.0) as pot:
             differential_mcp_test(mock, pot, 0, 1, 12, full=True)
 
-def test_MCP3302():
+def test_MCP3302(mock_factory):
     with patch('gpiozero.pins.local.SpiDev', None):
         mock = MockMCP3302(11, 10, 9, 8)
         with pytest.raises(ValueError):
@@ -367,7 +364,7 @@ def test_MCP3302():
         with MCP3302(channel=0, differential=True) as pot:
             differential_mcp_test(mock, pot, 0, 1, 12, full=True)
 
-def test_MCP3304():
+def test_MCP3304(mock_factory):
     with patch('gpiozero.pins.local.SpiDev', None):
         mock = MockMCP3304(11, 10, 9, 8)
         with pytest.raises(ValueError):
@@ -378,4 +375,3 @@ def test_MCP3304():
             single_mcp_test(mock, pot, 5, 12)
         with MCP3304(channel=5, differential=True) as pot:
             differential_mcp_test(mock, pot, 5, 4, 12, full=True)
-

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -27,10 +27,11 @@ try:
 except ImportError:
     from gpiozero.compat import median
 
+
 epsilon = 0.01  # time to sleep after setting source before checking value
 
-def test_set_source_by_value():
-    btn_pin = Device.pin_factory.pin(3)
+def test_set_source_by_value(mock_factory):
+    btn_pin = mock_factory.pin(3)
     with LED(2) as led, Button(3) as btn:
         led.source_delay = 0
         assert not led.value
@@ -44,8 +45,8 @@ def test_set_source_by_value():
         assert led.value
         assert btn.value
 
-def test_set_source_by_device():
-    btn_pin = Device.pin_factory.pin(3)
+def test_set_source_by_device(mock_factory):
+    btn_pin = mock_factory.pin(3)
     with LED(2) as led, Button(3) as btn:
         led.source_delay = 0
         assert not led.value
@@ -59,12 +60,12 @@ def test_set_source_by_device():
         assert led.value
         assert btn.value
 
-def test_negated():
+def test_negated(mock_factory):
     assert list(negated(())) == []
     assert list(negated((True, True, False, False))) == [False, False, True, True]
 
-def test_negated_with_device_values():
-    btn_pin = Device.pin_factory.pin(3)
+def test_negated_with_device_values(mock_factory):
+    btn_pin = mock_factory.pin(3)
     with LED(2) as led, Button(3) as btn:
         led.source_delay = 0
         assert not led.value
@@ -78,8 +79,8 @@ def test_negated_with_device_values():
         assert not led.value
         assert btn.value
 
-def test_negated_with_device():
-    btn_pin = Device.pin_factory.pin(3)
+def test_negated_with_device(mock_factory):
+    btn_pin = mock_factory.pin(3)
     with LED(2) as led, Button(3) as btn:
         led.source_delay = 0
         assert not led.value
@@ -149,7 +150,7 @@ def test_clamped():
     assert list(clamped((-2, -1, -0.5, 0, 0.5, 1, 2), -1, 1)) == [-1, -1, -0.5, 0, 0.5, 1, 1]
     assert list(clamped((-2, -1, -0.5, 0, 0.5, 1, 2), -2, 2)) == [-2, -1, -0.5, 0, 0.5, 1, 2]
 
-def test_absoluted():
+def test_absoluted(mock_factory):
     assert list(absoluted(())) == []
     assert list(absoluted((-2, -1, 0, 1, 2))) == [2, 1, 0, 1, 2]
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,8 @@ list_dependencies_command = echo {packages}
 skip_install = true
 # Now do everything manually...
 commands =
-    curl https://bootstrap.pypa.io/3.2/get-pip.py -o get-pip.py
-    python get-pip.py
+    curl https://bootstrap.pypa.io/3.2/get-pip.py -o get-pip32.py
+    python get-pip32.py
     pip install -e .[test]
     make test
 passenv = GPIOZERO_* COVERAGE_*
@@ -56,8 +56,8 @@ deps =
 list_dependencies_command = echo {packages}
 skip_install = true
 commands =
-    curl https://bootstrap.pypa.io/3.3/get-pip.py -o get-pip.py
-    python get-pip.py
+    curl https://bootstrap.pypa.io/3.3/get-pip.py -o get-pip33.py
+    python get-pip33.py
     pip install -e .[test]
     make test
 passenv = GPIOZERO_* COVERAGE_*

--- a/tox.ini
+++ b/tox.ini
@@ -6,16 +6,20 @@ deps = .[test]
 usedevelop = true
 commands = make test
 whitelist_externals = make
+setenv = COVERAGE_FILE=.coverage.{envname}
+passenv = GPIOZERO_* COVERAGE_*
 
 [testenv:py32]
 # All this shenanigans is to get tox (and everything else) working with python
 # 3.2. We stop venv for downloading or installing anything in the venv, because
 # all the local stuff almost certainly doesn't work on py3.2.
+basepython = python3.2
 setenv =
     VIRTUALENV_NO_DOWNLOAD=1
     VIRTUALENV_NO_PIP=1
     VIRTUALENV_NO_WHEEL=1
     VIRTUALENV_NO_SETUPTOOLS=1
+    COVERAGE_FILE=.coverage.{envname}
 # The following lines are needed to stop tox trying to install dependencies (or
 # anything else) itself because pip won't exist in the venv yet.
 whitelist_externals =
@@ -32,14 +36,17 @@ commands =
     python get-pip.py
     pip install -e .[test]
     make test
+passenv = GPIOZERO_* COVERAGE_*
 
 [testenv:py33]
 # Same story as above
+basepython = python3.3
 setenv =
     VIRTUALENV_NO_DOWNLOAD=1
     VIRTUALENV_NO_PIP=1
     VIRTUALENV_NO_WHEEL=1
     VIRTUALENV_NO_SETUPTOOLS=1
+    COVERAGE_FILE=.coverage.{envname}
 whitelist_externals =
     echo
     curl
@@ -53,3 +60,4 @@ commands =
     python get-pip.py
     pip install -e .[test]
     make test
+passenv = GPIOZERO_* COVERAGE_*

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,9 @@ deps = .[test]
 usedevelop = true
 commands = make test
 whitelist_externals = make
-setenv = COVERAGE_FILE=.coverage.{envname}
+setenv =
+    COVERAGE_FILE=.coverage.{envname}
+    GPIOZERO_TEST_LOCK={toxworkdir}/real_pins_lock
 passenv = GPIOZERO_* COVERAGE_*
 
 [testenv:py32]
@@ -20,6 +22,7 @@ setenv =
     VIRTUALENV_NO_WHEEL=1
     VIRTUALENV_NO_SETUPTOOLS=1
     COVERAGE_FILE=.coverage.{envname}
+    GPIOZERO_TEST_LOCK={toxworkdir}/real_pins_lock
 # The following lines are needed to stop tox trying to install dependencies (or
 # anything else) itself because pip won't exist in the venv yet.
 whitelist_externals =
@@ -28,12 +31,12 @@ whitelist_externals =
     pip
     make
 deps =
-list_dependencies_command = echo {packages}
+list_dependencies_command = echo
 skip_install = true
 # Now do everything manually...
 commands =
-    curl https://bootstrap.pypa.io/3.2/get-pip.py -o get-pip32.py
-    python get-pip32.py
+    curl https://bootstrap.pypa.io/3.2/get-pip.py -o {envdir}/get-pip32.py
+    python {envdir}/get-pip32.py
     pip install -e .[test]
     make test
 passenv = GPIOZERO_* COVERAGE_*
@@ -47,17 +50,18 @@ setenv =
     VIRTUALENV_NO_WHEEL=1
     VIRTUALENV_NO_SETUPTOOLS=1
     COVERAGE_FILE=.coverage.{envname}
+    GPIOZERO_TEST_LOCK={toxworkdir}/real_pins_lock
 whitelist_externals =
     echo
     curl
     pip
     make
 deps =
-list_dependencies_command = echo {packages}
+list_dependencies_command = echo
 skip_install = true
 commands =
-    curl https://bootstrap.pypa.io/3.3/get-pip.py -o get-pip33.py
-    python get-pip33.py
+    curl https://bootstrap.pypa.io/3.3/get-pip.py -o {envdir}/get-pip33.py
+    python {envdir}/get-pip33.py
     pip install -e .[test]
     make test
 passenv = GPIOZERO_* COVERAGE_*


### PR DESCRIPTION
Our coverage has been suffering a bit lately and needs a boost. This also fixes several bugs found along the way (I'd broken ButtonBoard two years ago and not noticed, and there was a *very* subtle bug in LocalFactory's hack of pin reservations), and tidies up the test suite to get rid of the ugly PWM-required lists (now there's just a pytest "pwm" fixture that can be added to any test requiring PWM).

Finally, this adds full support for later tox versions to permit parallel tests of various Python versions. It even supports this when testing physical pins by taking out a file-system level lock to prevent multiple interpreters hitting the pins at the same time. To try out the tox support, you can just run "tox" assuming you've got all the required Python interpreters installed (e.g. via the deadsnakes PPA on Ubuntu). If you haven't got all them installed, "tox -s" will skip missing interpreters. "tox -p auto -s" will run tests in parallel skipping missing interpreters. At the end you can run "coverage combine --rcfile coverage.cfg && coverage report --rcfile coverage.cfg" to receive a combined coverage report (unfortunately this seems to skip python 3.2 as the coverage file format changed from the ancient version in use with that interpreter ... oh well).