### PR TITLE
Show warning when when_activated/deactivated set to None (probably) by accident

### DIFF
--- a/docs/api_exc.rst
+++ b/docs/api_exc.rst
@@ -136,3 +136,4 @@ Warnings
 
 .. autoexception:: PinNonPhysical
 
+.. autoexception:: CallbackSetToNone

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -82,6 +82,13 @@ This will assign the function to the event handler *without calling it*. This
 is the crucial difference between ``my_function`` (a reference to a function)
 and ``my_function()`` (the result of calling a function).
 
+.. note::
+
+    Note that as of v1.5, setting a callback to ``None`` when it was previously
+    ``None`` will raise a :class:`CallbackSetToNone` warning, with the intention
+    of alerting users when callbacks are set to ``None`` accidentally. However,
+    if this is intentional, the warning can be suppressed. See the
+    :mod:`warnings` module for reference.
 
 .. _pinfactoryfallback-warnings:
 
@@ -247,9 +254,9 @@ that both callbacks will fire. Sometimes, this is acceptable, but often you'll
 want to only fire the :attr:`Button.when_pressed` callback when the button has
 not been held, only pressed.
 
-The way to achieve this is to *not* set a callback on when_pressed, and instead
-use :attr:`Button.when_released` to work out whether it had been held or just
-pressed::
+The way to achieve this is to *not* set a callback on
+:attr:`Button.when_pressed`, and instead use :attr:`Button.when_released` to
+work out whether it had been held or just pressed::
 
     from gpiozero import Button
 

--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -171,3 +171,6 @@ class PinNonPhysical(PinWarning):
 
 class ThresholdOutOfRange(GPIOZeroWarning):
     "Warning raised when a threshold is out of range specified by min and max values"
+
+class CallbackSetToNone(GPIOZeroWarning):
+    "Warning raised when a callback is set to None when its previous value was None"

--- a/gpiozero/mixins.py
+++ b/gpiozero/mixins.py
@@ -16,6 +16,7 @@ try:
     from statistics import median
 except ImportError:
     from .compat import median
+import warnings
 
 from .threads import GPIOThread
 from .exc import (
@@ -23,7 +24,13 @@ from .exc import (
     BadWaitTime,
     BadQueueLen,
     DeviceClosed,
+    CallbackSetToNone,
     )
+
+callback_warning = (
+    'The callback was set to None. This may have been unintentional '
+    'e.g. btn.when_pressed = pressed() instead of btn.when_pressed = pressed'
+)
 
 class ValuesMixin(object):
     """
@@ -204,6 +211,8 @@ class EventsMixin(object):
 
     @when_activated.setter
     def when_activated(self, value):
+        if self.when_activated is None and value is None:
+            warnings.warn(CallbackSetToNone(callback_warning))
         self._when_activated = self._wrap_callback(value)
 
     @property
@@ -224,6 +233,8 @@ class EventsMixin(object):
 
     @when_deactivated.setter
     def when_deactivated(self, value):
+        if self.when_deactivated is None and value is None:
+            warnings.warn(CallbackSetToNone(callback_warning))
         self._when_deactivated = self._wrap_callback(value)
 
     @property

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -102,6 +102,21 @@ def test_input_event_deactivated(mock_factory):
         pin.drive_low()
         assert event.is_set()
 
+def test_input_activated_callback_warning(mock_factory):
+    def foo(): pass
+
+    with DigitalInputDevice(4) as device:
+        with warnings.catch_warnings(record=True) as w:
+            device.when_activated = foo()
+            assert len(w) == 1
+            assert w[0].category == CallbackSetToNone
+
+    with DigitalInputDevice(4) as device:
+        with warnings.catch_warnings(record=True) as w:
+            device.when_deactivated = foo()
+            assert len(w) == 1
+            assert w[0].category == CallbackSetToNone
+
 def test_input_partial_callback(mock_factory):
     event = Event()
     pin = mock_factory.pin(4)


### PR DESCRIPTION
@lurch's brilliant suggestion in #136.