### PR TITLE
We can't read the value of an Energenie socket, so we shouldn't allow…

### DIFF
--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -56,6 +56,7 @@ from .exc import (
     GPIOPinMissing,
     EnergenieSocketMissing,
     EnergenieBadSocket,
+    EnergenieBadInitialValue,
     OutputDeviceBadValue,
     )
 from .input_devices import Button
@@ -2015,6 +2016,8 @@ class Energenie(SourceMixin, Device):
             raise EnergenieSocketMissing('socket number must be provided')
         if not (1 <= socket <= 4):
             raise EnergenieBadSocket('socket number must be between 1 and 4')
+        if initial_value is None:
+            raise EnergenieBadInitialValue("initial value can't be None")
         self._value = None
         super(Energenie, self).__init__(pin_factory=pin_factory)
         self._socket = socket

--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -77,6 +77,9 @@ class EnergenieSocketMissing(CompositeDeviceError, ValueError):
 class EnergenieBadSocket(CompositeDeviceError, ValueError):
     "Error raised when an invalid socket number is passed to :class:`Energenie`"
 
+class EnergenieBadInitialValue(CompositeDeviceError, ValueError):
+    "Error raised when an invalid initial value is passed to :class:`Energenie`"
+
 class SPIError(GPIOZeroError):
     "Base class for errors related to the SPI implementation"
 

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -1258,6 +1258,8 @@ def test_energenie_bad_init(mock_factory):
         Energenie(0)
     with pytest.raises(ValueError):
         Energenie(5)
+    with pytest.raises(ValueError):
+        Energenie(1, initial_value=None)
 
 def test_energenie(mock_factory):
     pins = [mock_factory.pin(n) for n in (17, 22, 23, 27, 24, 25)]


### PR DESCRIPTION
… a None initial_value

See https://github.com/RPi-Distro/python-gpiozero/issues/323#issuecomment-218543961