### PR TITLE
py2.7 failure on Travis

### DIFF
--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -183,16 +183,6 @@ def test_input_init_fail(mock_factory):
         DigitalInputDevice(4, bounce_time='foo')
     with pytest.raises(ValueError):
         SmoothedInputDevice(4, threshold='foo')
-    with mock.patch('gpiozero.threads.GPIOThread.start') as start:
-        start.side_effect = RuntimeError('failed to start thread')
-        with pytest.raises(RuntimeError):
-            LineSensor(4)
-        with pytest.raises(RuntimeError):
-            MotionSensor(4)
-        with pytest.raises(RuntimeError):
-            LightSensor(4)
-        with pytest.raises(RuntimeError):
-            DistanceSensor(4, 5)
 
 def test_input_smoothed_attrib(mock_factory):
     pin = mock_factory.pin(4)


### PR DESCRIPTION
This branch appears to fix the py2.7 build failures on Travis. I'm not 100% certain why, but it's *something* to do with a threading lockup (almost certainly when joining the threads when cleaning up the test). The reason I'm not sure, is the test is working perfectly locally (on py2.7.12) but failing on Travis (on py2.7.14). Also, the join *should* be obeying a 10 second timeout at the worst. Anyway, no time to figure out the details now.