### PR TITLE
Fix #795 for overvolted Pis. Also minor tweaks to ASCII-art.

### DIFF
--- a/gpiozero/pins/data.py
+++ b/gpiozero/pins/data.py
@@ -173,7 +173,7 @@ B3PLUS_BOARD = """\
 {style:white on green}|        {style:black on white},----.{style:on green}               {style:black on white}+===={style:reset}
 {style:white on green}| {style:on black}|D|{style:on green}    {style:black on white}|SoC |{style:on green}               {style:black on white}| USB{style:reset}
 {style:white on green}| {style:on black}|S|{style:on green}    {style:black on white}|    |{style:on green}               {style:black on white}+===={style:reset}
-{style:white on green}| {style:on black}|I|{style:on green}    {style:black on white}`----'{style:on green}                  |{style:reset}
+{style:white on green}| {style:on black}|I|{style:on green}    {style:black on white}`----'{style:white on green}                  |{style:reset}
 {style:white on green}|                   {style:on black}|C|{style:on green}     {style:black on white}+======{style:reset}
 {style:white on green}|                   {style:on black}|S|{style:on green}     {style:black on white}|   Net{style:reset}
 {style:white on green}| {style:black on white}pwr{style:white on green}        {style:black on white}|HDMI|{style:white on green} {style:on black}|I||A|{style:on green}  {style:black on white}+======{style:reset}
@@ -203,7 +203,7 @@ A3PLUS_BOARD = """\
 {style:white on green}|        {style:black on white},----.{style:on green}         {style:black on white}+===={style:reset}
 {style:white on green}| {style:on black}|D|{style:on green}    {style:black on white}|SoC |{style:on green}         {style:black on white}| USB{style:reset}
 {style:white on green}| {style:on black}|S|{style:on green}    {style:black on white}|    |{style:on green}         {style:black on white}+===={style:reset}
-{style:white on green}| {style:on black}|I|{style:on green}    {style:black on white}`----'{style:on green}            |{style:reset}
+{style:white on green}| {style:on black}|I|{style:on green}    {style:black on white}`----'{style:white on green}            |{style:reset}
 {style:white on green}|                   {style:on black}|C|{style:on green}    |{style:reset}
 {style:white on green}|                   {style:on black}|S|{style:on green}    |{style:reset}
 {style:white on green}| {style:black on white}pwr{style:white on green}        {style:black on white}|HDMI|{style:white on green} {style:on black}|I||A|{style:on green} |{style:reset}

--- a/gpiozero/pins/local.py
+++ b/gpiozero/pins/local.py
@@ -90,9 +90,10 @@ class LocalPiFactory(PiFactory):
         self._res_lock = LocalPiFactory._res_lock
 
     def _get_revision(self):
+        revision = None
         try:
             with io.open('/proc/device-tree/system/linux,revision', 'rb') as f:
-                return struct.unpack(nstr('>L'), f.read(4))[0]
+                revision = hex(struct.unpack(nstr('>L'), f.read(4))[0])[2:]
         except IOError as e:
             if e.errno != errno.ENOENT:
                 raise e
@@ -100,11 +101,12 @@ class LocalPiFactory(PiFactory):
                 for line in f:
                     if line.startswith('Revision'):
                         revision = line.split(':')[1].strip().lower()
-                        overvolted = revision.startswith('100')
-                        if overvolted:
-                            revision = revision[-4:]
-                        return int(revision, base=16)
-        raise PinUnknownPi('unable to locate Pi revision in /proc/cpuinfo or /proc/device-tree')
+        if revision is not None:
+            overvolted = revision.startswith('100')
+            if overvolted:
+                revision = revision[-4:]
+            return int(revision, base=16)
+        raise PinUnknownPi('unable to locate Pi revision in /proc/device-tree or /proc/cpuinfo')
 
     @staticmethod
     def ticks():


### PR DESCRIPTION
On an overvolted original-model A Pi, `/proc/device-tree/system/linux,revision` has the (binary) value 01 00 00 08